### PR TITLE
Task/api 1160 edit coverage eligibility response model for da rs

### DIFF
--- a/r4/README.md
+++ b/r4/README.md
@@ -4,7 +4,10 @@ All models required to build R4 resources and datatypes are housed here.
 This includes Java models for all R4 supported resources (below), and all needed datatypes.
 Also includes the appropriate tests for each Java model.
 
+Because validation logic is shared among all FHIR versions, it has been pulled out into its own module.
+
 Current Supported Resources:
-  * Patient
+  * Coverage
   * CoverageEligibilityResponse
+  * Patient
 

--- a/r4/checkstyle-suppressions.xml
+++ b/r4/checkstyle-suppressions.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <!--
+    The following resources have certain fields that are reported
+    as data absent reason extensions that is required to have a _
+    prefix by the Data Query specification.
+  -->
+  <suppress checks="MemberName" files=".*(/|\\)CoverageEligibilityResponse.java" message="Member name '(_coverage|_request)'"/>
+</suppressions>

--- a/r4/pom.xml
+++ b/r4/pom.xml
@@ -10,6 +10,9 @@
   <artifactId>r4</artifactId>
   <version>1.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
+  <properties>
+    <checkstyle.suppressions.location>${project.basedir}/checkstyle-suppressions.xml</checkstyle.suppressions.location>
+  </properties>
   <dependencies>
     <!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
     <dependency>
@@ -30,26 +33,6 @@
       <version>5.0.4.Final</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>5.3.7.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
-      <version>2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <version>6.0.14.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.common</groupId>
-      <artifactId>hibernate-commons-annotations</artifactId>
-      <version>5.0.4.Final</version>
-    </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityResponse.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityResponse.java
@@ -18,6 +18,7 @@ import gov.va.api.health.r4.api.elements.Extension;
 import gov.va.api.health.r4.api.elements.Meta;
 import gov.va.api.health.r4.api.elements.Narrative;
 import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.validation.api.ExactlyOneOf;
 import gov.va.api.health.validation.api.ZeroOrOneOf;
 import gov.va.api.health.validation.api.ZeroOrOneOfs;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -48,7 +49,11 @@ import lombok.NoArgsConstructor;
 )
 @ZeroOrOneOf(
   fields = {"servicedDate", "servicedPeriod"},
-  message = "Only one serviced value may be specified"
+  message = "Only one serviced value may be specified."
+)
+@ExactlyOneOf(
+  fields = {"request", "_request"},
+  message = "Exactly one request value must be specified."
 )
 public class CoverageEligibilityResponse implements Resource {
   // Anscestor -- Resource
@@ -88,7 +93,8 @@ public class CoverageEligibilityResponse implements Resource {
 
   @Valid Reference requestor;
 
-  @NotNull @Valid Reference request;
+  @Valid Reference request;
+  @Valid Extension _request;
 
   @NotNull Outcome outcome;
 
@@ -199,6 +205,10 @@ public class CoverageEligibilityResponse implements Resource {
   @AllArgsConstructor
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @Schema(name = "Insurance")
+  @ExactlyOneOf(
+    fields = {"coverage", "_coverage"},
+    message = "Exactly one coverage value must be specified."
+  )
   public static class Insurance implements BackboneElement {
     @Pattern(regexp = Fhir.ID)
     String id;
@@ -207,7 +217,8 @@ public class CoverageEligibilityResponse implements Resource {
 
     @Valid List<Extension> modifierExtension;
 
-    @NotNull @Valid Reference coverage;
+    @Valid Reference coverage;
+    @Valid Extension _coverage;
 
     @Pattern(regexp = Fhir.BOOLEAN)
     String inforce;

--- a/r4/src/test/java/gov/va/api/health/r4/api/AbstractRelatedFieldVerifier.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/AbstractRelatedFieldVerifier.java
@@ -21,6 +21,7 @@ import gov.va.api.health.r4.api.datatypes.SimpleQuantity;
 import gov.va.api.health.r4.api.datatypes.SimpleResource;
 import gov.va.api.health.r4.api.datatypes.UsageContext;
 import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Reference;
 import gov.va.api.health.r4.api.samples.SampleDataTypes;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
@@ -113,6 +114,7 @@ public abstract class AbstractRelatedFieldVerifier<T> {
     suppliers.put(Ratio.class, dataTypes::extensionWithRatio);
     suppliers.put(Signature.class, dataTypes::signature);
     suppliers.put(SimpleQuantity.class, dataTypes::simpleQuantity);
+    suppliers.put(Reference.class, dataTypes::reference);
     suppliers.put(SimpleResource.class, dataTypes::resource);
     suppliers.put(UsageContext.class, dataTypes::usageContext);
     return suppliers;

--- a/r4/src/test/java/gov/va/api/health/r4/api/ExactlyOneOfExtensionVerifier.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/ExactlyOneOfExtensionVerifier.java
@@ -1,0 +1,47 @@
+package gov.va.api.health.r4.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.health.r4.api.elements.Extension;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class will verify fields with a field required by FHIR but not available for us is
+ * represented by an ExactlyOneOf annotation that follows the name + _name convention where the
+ * _name is an Extension object.
+ */
+@Slf4j
+public class ExactlyOneOfExtensionVerifier<T> extends AbstractRelatedFieldVerifier<T> {
+  /** The base of the related fields, e.g. status vs _status. */
+  private String baseField;
+
+  @Builder
+  public ExactlyOneOfExtensionVerifier(T sample, String field) {
+    super(sample, name -> name.equals(field) || name.equals("_" + field));
+    baseField = field;
+  }
+
+  @Override
+  public void verify() {
+    log.info("Verifying {}", sample.getClass());
+    String extensionField = "_" + baseField;
+    assertThat(fields()).containsExactlyInAnyOrder(baseField, extensionField);
+
+    /* Make sure the sample is valid before we mess it up. */
+    assertProblems(0);
+
+    /* Make sure we are valid if no fields are set. */
+    unsetFields();
+    assertProblems(1);
+
+    setField(baseField);
+    assertProblems(0);
+
+    unsetFields();
+    setField(extensionField);
+    assertProblems(0);
+
+    assertThat(field(extensionField).getType()).isEqualTo(Extension.class);
+  }
+}

--- a/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityResponseTest.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityResponseTest.java
@@ -4,6 +4,7 @@ import static gov.va.api.health.r4.api.RoundTrip.assertRoundTrip;
 import static gov.va.api.health.r4.api.bundle.AbstractBundle.BundleType.searchset;
 import static java.util.Collections.singletonList;
 
+import gov.va.api.health.r4.api.ExactlyOneOfExtensionVerifier;
 import gov.va.api.health.r4.api.ZeroOrOneOfVerifier;
 import gov.va.api.health.r4.api.bundle.BundleLink;
 import gov.va.api.health.r4.api.bundle.BundleLink.LinkRelation;
@@ -54,6 +55,7 @@ public class CoverageEligibilityResponseTest {
   @Test
   public void coverageEligibilityResponse() {
     assertRoundTrip(data.coverageEligibilityResponse());
+    assertRoundTrip(data.coverageEligibilityResponseWithDataAbsentReason());
   }
 
   @Test
@@ -65,5 +67,25 @@ public class CoverageEligibilityResponseTest {
         .verify();
     ZeroOrOneOfVerifier.builder().sample(data.benefit()).fieldPrefix("allowed").build().verify();
     ZeroOrOneOfVerifier.builder().sample(data.benefit()).fieldPrefix("used").build().verify();
+    ExactlyOneOfExtensionVerifier.builder()
+        .sample(data.coverageEligibilityResponse())
+        .field("request")
+        .build()
+        .verify();
+    ExactlyOneOfExtensionVerifier.builder()
+        .sample(data.coverageEligibilityResponseWithDataAbsentReason())
+        .field("request")
+        .build()
+        .verify();
+    ExactlyOneOfExtensionVerifier.builder()
+        .sample(data.insurance())
+        .field("coverage")
+        .build()
+        .verify();
+    ExactlyOneOfExtensionVerifier.builder()
+        .sample(data.insuranceWithDataAbsentReason())
+        .field("coverage")
+        .build()
+        .verify();
   }
 }

--- a/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleCoverageEligibilityResponses.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleCoverageEligibilityResponses.java
@@ -3,6 +3,8 @@ package gov.va.api.health.r4.api.samples;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
+import gov.va.api.health.r4.api.DataAbsentReason;
+import gov.va.api.health.r4.api.DataAbsentReason.Reason;
 import gov.va.api.health.r4.api.resources.CoverageEligibilityResponse;
 import gov.va.api.health.r4.api.resources.CoverageEligibilityResponse.Benefit;
 import gov.va.api.health.r4.api.resources.CoverageEligibilityResponse.CoverageEligibilityResponseError;
@@ -56,6 +58,12 @@ public class SampleCoverageEligibilityResponses {
         .build();
   }
 
+  public CoverageEligibilityResponse coverageEligibilityResponseWithDataAbsentReason() {
+    return coverageEligibilityResponse()
+        ._request(DataAbsentReason.of(Reason.unsupported))
+        .request(null);
+  }
+
   public CoverageEligibilityResponseError error() {
     return CoverageEligibilityResponseError.builder().code(codeableConcept()).build();
   }
@@ -67,6 +75,10 @@ public class SampleCoverageEligibilityResponses {
         .benefitPeriod(period())
         .item(singletonList(item()))
         .build();
+  }
+
+  public Insurance insuranceWithDataAbsentReason() {
+    return insurance().coverage(null)._coverage(DataAbsentReason.of(Reason.unsupported));
   }
 
   public Item item() {


### PR DESCRIPTION
Fields request and coverage are required in the CoverageEligibilityResponse R4 specification. They are each of types that we do not support, and are hence going to become DARs.
Related story: https://vasdvp.atlassian.net/browse/API-1160