### PR TITLE
Pull in base64 fix

### DIFF
--- a/dstu2/src/main/java/gov/va/api/health/dstu2/api/Fhir.java
+++ b/dstu2/src/main/java/gov/va/api/health/dstu2/api/Fhir.java
@@ -21,7 +21,7 @@ public class Fhir {
 
   @Schema(description = "http://hl7.org/fhir/DSTU2/datatypes.html#base64binary")
   public static final String BASE64 =
-      "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)";
+      "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$";
 
   @Schema(description = "http://hl7.org/fhir/DSTU2/datatypes.html#date")
   public static final String DATE = "-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1]))?)?";

--- a/dstu2/src/test/java/gov/va/api/health/dstu2/api/FhirTest.java
+++ b/dstu2/src/test/java/gov/va/api/health/dstu2/api/FhirTest.java
@@ -4,9 +4,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 public class FhirTest {
+
+  @Test
+  public void base64RegexDoesNotMatchBadStrings() {
+    // Make sure that = is only allowed as the last 1 or 2 characters of the string.
+    assertThat(Pattern.matches(Fhir.BASE64, "SSBqdXN0IGF0ZSBhIHBlYW51dA=o"))
+        .withFailMessage("Padding character in wrong location is invalid but was not rejected.")
+        .isFalse();
+    assertThat(Pattern.matches(Fhir.BASE64, ""))
+        .withFailMessage("Empty string is invalid but was not rejected.")
+        .isFalse();
+    assertThat(Pattern.matches(Fhir.BASE64, "SSBqdXN0IGF0ZSBhIHBlYW51dAo"))
+        .withFailMessage("Missing padding/improper size is invalid but was not rejected.")
+        .isFalse();
+  }
+
+  @Test
+  public void base64RegexMatchesGoodStrings() {
+    // There are two separate cases in the regex that should be tested. < and > 4 characters.
+    assertThat(Pattern.matches(Fhir.BASE64, "QUJD"))
+        .withFailMessage("Failed short, valid BASE64 without padding.")
+        .isTrue();
+    assertThat(Pattern.matches(Fhir.BASE64, "QUI="))
+        .withFailMessage("Failed short, valid BASE64 with one padding char.")
+        .isTrue();
+    assertThat(Pattern.matches(Fhir.BASE64, "QQ=="))
+        .withFailMessage("Failed short, valid BASE64 with two padding chars.")
+        .isTrue();
+    assertThat(Pattern.matches(Fhir.BASE64, "SSBhdGUgbWFueSBwZWFudXRz"))
+        .withFailMessage("Failed long, valid BASE64 without padding.")
+        .isTrue();
+    assertThat(Pattern.matches(Fhir.BASE64, "SSBqdXN0IGF0ZSBhIHBlYW51dAo="))
+        .withFailMessage("Failed long, valid BASE64 with one padding char.")
+        .isTrue();
+    assertThat(Pattern.matches(Fhir.BASE64, "SSBhdGUgYSBmZXcgcGVhbnV0cw=="))
+        .withFailMessage("Failed long, valid BASE64 with two padding chars.")
+        .isTrue();
+  }
+
   /**
    * Datetime is a union of xs:dateTime, xs:date, xs:gYearMonth, xs:gYear. See
    * http://hl7.org/fhir/DSTU2/datatypes.html#datetime


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/ADQ-27

There was a fix pushed to health-apis-data-query between when a refactor took place and the fhir-resources repo PR for it went through.