### PR TITLE
API-1561 - Model Claim and CoverageEligibilityRequest

### DIFF
--- a/r4/README.md
+++ b/r4/README.md
@@ -7,7 +7,9 @@ Also includes the appropriate tests for each Java model.
 Because validation logic is shared among all FHIR versions, it has been pulled out into its own module.
 
 Current Supported Resources:
+  * Claim
   * Coverage
+  * CoverageEligibilityRequest
   * CoverageEligibilityResponse
   * Patient
 

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
@@ -1,0 +1,566 @@
+package gov.va.api.health.r4.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.va.api.health.r4.api.Fhir;
+import gov.va.api.health.r4.api.datatypes.Address;
+import gov.va.api.health.r4.api.datatypes.Attachment;
+import gov.va.api.health.r4.api.datatypes.CodeableConcept;
+import gov.va.api.health.r4.api.datatypes.Identifier;
+import gov.va.api.health.r4.api.datatypes.Money;
+import gov.va.api.health.r4.api.datatypes.Period;
+import gov.va.api.health.r4.api.datatypes.Quantity;
+import gov.va.api.health.r4.api.datatypes.SimpleQuantity;
+import gov.va.api.health.r4.api.datatypes.SimpleResource;
+import gov.va.api.health.r4.api.elements.BackboneElement;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Meta;
+import gov.va.api.health.r4.api.elements.Narrative;
+import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.validation.api.ExactlyOneOf;
+import gov.va.api.health.validation.api.ZeroOrOneOf;
+import gov.va.api.health.validation.api.ZeroOrOneOfs;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@JsonAutoDetect(
+  fieldVisibility = JsonAutoDetect.Visibility.ANY,
+  isGetterVisibility = JsonAutoDetect.Visibility.NONE
+)
+@Schema(description = "https://www.hl7.org/fhir/R4/claim.html", example = "SWAGGER_EXAMPLE_CLAIM")
+public class Claim implements Resource {
+
+  // Ancestor -- Resource
+  @Pattern(regexp = Fhir.ID)
+  String id;
+
+  @NotBlank String resourceType;
+
+  @Valid Meta meta;
+
+  @Pattern(regexp = Fhir.URI)
+  String implicitRules;
+
+  @Pattern(regexp = Fhir.CODE)
+  String language;
+
+  // Ancestor -- DomainResource
+  @Valid Narrative text;
+
+  @Valid List<SimpleResource> contained;
+
+  @Valid List<Extension> extension;
+
+  @Valid List<Extension> modifierExtension;
+
+  // Claim Resource
+  @Valid List<Identifier> identifier;
+
+  @NotNull Status status;
+
+  @NotNull @Valid CodeableConcept type;
+
+  @Valid CodeableConcept subType;
+
+  @NotNull Use use;
+
+  @NotNull @Valid Reference patient;
+
+  @Valid Period billablePeriod;
+
+  @NotBlank
+  @Pattern(regexp = Fhir.DATETIME)
+  String created;
+
+  @Valid Reference enterer;
+
+  @Valid Reference insurer;
+
+  @NotNull @Valid Reference provider;
+
+  @NotNull @Valid CodeableConcept priority;
+
+  @Valid CodeableConcept fundsReserve;
+
+  @Valid List<Related> related;
+
+  @Valid Reference prescription;
+
+  @Valid Reference originalPrescription;
+
+  @Valid Payee payee;
+
+  @Valid Reference referral;
+
+  @Valid Reference facility;
+
+  @Valid List<CareTeam> careTeam;
+
+  @Valid List<SupportingInfo> supportingInfo;
+
+  @Valid List<Diagnosis> diagnosis;
+
+  @Valid List<Procedure> procedure;
+
+  @NotEmpty @Valid List<Insurance> insurance;
+
+  @Valid Accident accident;
+
+  @Valid List<Item> item;
+
+  @Valid Money total;
+
+  public enum Status {
+    active,
+    cancelled,
+    draft,
+    @JsonProperty("entered-in-error")
+    entered_in_error
+  }
+
+  public enum Use {
+    claim,
+    preauthorization,
+    predetermination
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimRelated")
+  public static class Related implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @Valid Reference claim;
+
+    @Valid CodeableConcept relationship;
+
+    @Valid Identifier reference;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimPayee")
+  public static class Payee implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotNull @Valid CodeableConcept type;
+
+    @Valid Reference party;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimCareTeam")
+  public static class CareTeam implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @NotNull @Valid Reference provider;
+
+    @Pattern(regexp = Fhir.BOOLEAN)
+    String responsible;
+
+    @Valid CodeableConcept role;
+
+    @Valid CodeableConcept qualification;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimSupportingInfo")
+  @ZeroOrOneOfs({
+    @ZeroOrOneOf(
+      fields = {"timingDate", "timingPeriod"},
+      message = "Only one timing field may be specified"
+    ),
+    @ZeroOrOneOf(
+      fields = {
+        "valueBoolean",
+        "valueString",
+        "valueQuantity",
+        "valueAttachment",
+        "valueReference"
+      },
+      message = "Only one value field may be specified"
+    )
+  })
+  public static class SupportingInfo implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @NotNull @Valid CodeableConcept category;
+
+    @Valid CodeableConcept code;
+
+    @Pattern(regexp = Fhir.DATE)
+    String timingDate;
+
+    @Valid Period timingPeriod;
+
+    @Pattern(regexp = Fhir.BOOLEAN)
+    String valueBoolean;
+
+    @Pattern(regexp = Fhir.STRING)
+    String valueString;
+
+    @Valid Quantity valueQuantity;
+
+    @Valid Attachment valueAttachment;
+
+    @Valid Reference valueReference;
+
+    @Valid CodeableConcept reason;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimDiagnosis")
+  @ExactlyOneOf(
+    fields = {"diagnosisCodeableConcept", "diagnosisReference"},
+    message = "diagnosisCodeableConcept or diagnosisReference, but not both"
+  )
+  public static class Diagnosis implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @Valid CodeableConcept diagnosisCodeableConcept;
+
+    @Valid Reference diagnosisReference;
+
+    @Valid List<CodeableConcept> type;
+
+    @Valid CodeableConcept onAdmission;
+
+    @Valid CodeableConcept packageCode;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimProcedure")
+  @ExactlyOneOf(
+    fields = {"procedureCodeableConcept", "procedureReference"},
+    message = "procedureCodeableConcept or procedureReference, but not both"
+  )
+  public static class Procedure implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @Valid CodeableConcept type;
+
+    @Pattern(regexp = Fhir.DATETIME)
+    String date;
+
+    @Valid CodeableConcept procedureCodeableConcept;
+
+    @Valid Reference procedureReference;
+
+    @Valid List<Reference> udi;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimInsurance")
+  public static class Insurance implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.BOOLEAN)
+    String focal;
+
+    @Valid Identifier identifier;
+
+    @NotNull @Valid Reference coverage;
+
+    @Pattern(regexp = Fhir.STRING)
+    String businessArrangement;
+
+    @Valid List<@Pattern(regexp = Fhir.STRING) String> preAuthRef;
+
+    @Valid Reference claimResponse;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimAccident")
+  @ZeroOrOneOf(
+    fields = {"locationAddress", "locationReference"},
+    message = "Only one location field may be specified"
+  )
+  public static class Accident implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.DATE)
+    String date;
+
+    @Valid CodeableConcept type;
+
+    @Valid Address locationAddress;
+
+    @Valid Reference locationReference;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "ClaimItem")
+  @ZeroOrOneOfs({
+    @ZeroOrOneOf(
+      fields = {"servicedDate", "servicedPeriod"},
+      message = "Only one serviced field may be specified"
+    ),
+    @ZeroOrOneOf(
+      fields = {"locationCodeableConcept", "locationAddress", "locationReference"},
+      message = "Only one location field may be specified"
+    )
+  })
+  public static class Item implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> careTeamSequence;
+
+    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> diagnosisSequence;
+
+    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> procedureSequence;
+
+    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> informationSequence;
+
+    @Valid CodeableConcept revenue;
+
+    @Valid CodeableConcept category;
+
+    @NotNull @Valid CodeableConcept productOrService;
+
+    @Valid List<CodeableConcept> modifier;
+
+    @Valid List<CodeableConcept> programCode;
+
+    @Pattern(regexp = Fhir.DATE)
+    String servicedDate;
+
+    @Valid Period servicedPeriod;
+
+    @Valid CodeableConcept locationCodeableConcept;
+
+    @Valid Address locationAddress;
+
+    @Valid Reference locationReference;
+
+    @Valid SimpleQuantity quantity;
+
+    @Valid Money unitPrice;
+
+    @Pattern(regexp = Fhir.DECIMAL)
+    String factor;
+
+    @Valid Money net;
+
+    @Valid List<Reference> udi;
+
+    @Valid CodeableConcept bodySite;
+
+    @Valid List<CodeableConcept> subSite;
+
+    @Valid List<Reference> encounter;
+
+    @Valid List<Detail> detail;
+
+    @Data
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @Schema(name = "ClaimItemDetail")
+    public static class Detail implements BackboneElement {
+
+      @Pattern(regexp = Fhir.ID)
+      String id;
+
+      @Valid List<Extension> extension;
+
+      @Valid List<Extension> modifierExtension;
+
+      @NotBlank
+      @Pattern(regexp = Fhir.POSITIVE_INT)
+      String sequence;
+
+      @Valid CodeableConcept revenue;
+
+      @Valid CodeableConcept category;
+
+      @NotNull @Valid CodeableConcept productOrService;
+
+      @Valid List<CodeableConcept> modifier;
+
+      @Valid List<CodeableConcept> programCode;
+
+      @Valid SimpleQuantity quantity;
+
+      @Valid Money unitPrice;
+
+      @Pattern(regexp = Fhir.DECIMAL)
+      String factor;
+
+      @Valid Money net;
+
+      @Valid List<Reference> udi;
+
+      @Valid List<SubDetail> subDetail;
+
+      @Data
+      @Builder
+      @NoArgsConstructor(access = AccessLevel.PRIVATE)
+      @AllArgsConstructor
+      @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+      @Schema(name = "ClaimItemDetailSubDetail")
+      public static class SubDetail implements BackboneElement {
+
+        @Pattern(regexp = Fhir.ID)
+        String id;
+
+        @Valid List<Extension> extension;
+
+        @Valid List<Extension> modifierExtension;
+
+        @NotBlank
+        @Pattern(regexp = Fhir.POSITIVE_INT)
+        String sequence;
+
+        @Valid CodeableConcept revenue;
+
+        @Valid CodeableConcept category;
+
+        @NotNull @Valid CodeableConcept productOrService;
+
+        @Valid List<CodeableConcept> modifier;
+
+        @Valid List<CodeableConcept> programCode;
+
+        @Valid SimpleQuantity quantity;
+
+        @Valid Money unitPrice;
+
+        @Pattern(regexp = Fhir.DECIMAL)
+        String factor;
+
+        @Valid Money net;
+
+        @Valid List<Reference> udi;
+      }
+    }
+  }
+}

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
@@ -367,7 +367,7 @@ public class Claim implements Resource {
     @Pattern(regexp = Fhir.STRING)
     String businessArrangement;
 
-    @Valid List<@Pattern(regexp = Fhir.STRING) String> preAuthRef;
+    List<@Pattern(regexp = Fhir.STRING) String> preAuthRef;
 
     @Valid Reference claimResponse;
   }
@@ -431,13 +431,13 @@ public class Claim implements Resource {
     @Pattern(regexp = Fhir.POSITIVE_INT)
     String sequence;
 
-    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> careTeamSequence;
+    List<@Pattern(regexp = Fhir.POSITIVE_INT) String> careTeamSequence;
 
-    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> diagnosisSequence;
+    List<@Pattern(regexp = Fhir.POSITIVE_INT) String> diagnosisSequence;
 
-    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> procedureSequence;
+    List<@Pattern(regexp = Fhir.POSITIVE_INT) String> procedureSequence;
 
-    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> informationSequence;
+    List<@Pattern(regexp = Fhir.POSITIVE_INT) String> informationSequence;
 
     @Valid CodeableConcept revenue;
 

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/Claim.java
@@ -325,7 +325,7 @@ public class Claim implements Resource {
     @Pattern(regexp = Fhir.POSITIVE_INT)
     String sequence;
 
-    @Valid CodeableConcept type;
+    @Valid List<CodeableConcept> type;
 
     @Pattern(regexp = Fhir.DATETIME)
     String date;

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequest.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequest.java
@@ -1,0 +1,230 @@
+package gov.va.api.health.r4.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.va.api.health.r4.api.Fhir;
+import gov.va.api.health.r4.api.datatypes.CodeableConcept;
+import gov.va.api.health.r4.api.datatypes.Identifier;
+import gov.va.api.health.r4.api.datatypes.Money;
+import gov.va.api.health.r4.api.datatypes.Period;
+import gov.va.api.health.r4.api.datatypes.SimpleQuantity;
+import gov.va.api.health.r4.api.datatypes.SimpleResource;
+import gov.va.api.health.r4.api.elements.BackboneElement;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Meta;
+import gov.va.api.health.r4.api.elements.Narrative;
+import gov.va.api.health.r4.api.elements.Reference;
+import gov.va.api.health.validation.api.ZeroOrOneOf;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@JsonAutoDetect(
+  fieldVisibility = JsonAutoDetect.Visibility.ANY,
+  isGetterVisibility = JsonAutoDetect.Visibility.NONE
+)
+@Schema(
+  description = "https://www.hl7.org/fhir/R4/coverageeligibilityrequest.html",
+  example = "SWAGGER_EXAMPLE_COVERAGEELIGIBILITYREQUEST"
+)
+@ZeroOrOneOf(
+  fields = {"servicedDate", "servicedPeriod"},
+  message = "Only one serviced value may be specified."
+)
+public class CoverageEligibilityRequest implements Resource {
+
+  // Ancestor -- Resource
+  @Pattern(regexp = Fhir.ID)
+  String id;
+
+  @NotBlank String resourceType;
+
+  @Valid Meta meta;
+
+  @Pattern(regexp = Fhir.URI)
+  String implicitRules;
+
+  @Pattern(regexp = Fhir.CODE)
+  String language;
+
+  // Ancestor -- DomainResource
+  @Valid Narrative text;
+
+  @Valid List<SimpleResource> contained;
+
+  @Valid List<Extension> extension;
+
+  @Valid List<Extension> modifierExtension;
+
+  // CoverageEligibilityRequest Resource
+  @Valid List<Identifier> identifier;
+
+  @NotNull Status status;
+
+  @Valid CodeableConcept priority;
+
+  @NotEmpty List<Purpose> purpose;
+
+  @NotNull @Valid Reference patient;
+
+  @Pattern(regexp = Fhir.DATE)
+  String servicedDate;
+
+  @Valid Period servicedPeriod;
+
+  @NotBlank
+  @Pattern(regexp = Fhir.DATETIME)
+  String created;
+
+  @Valid Reference enterer;
+
+  @Valid Reference provider;
+
+  @NotNull @Valid Reference insurer;
+
+  @Valid Reference facility;
+
+  @Valid List<SupportingInfo> supportingInfo;
+
+  @Valid List<Insurance> insurance;
+
+  @Valid List<Item> item;
+
+  public enum Status {
+    active,
+    cancelled,
+    draft,
+    @JsonProperty("entered-in-error")
+    entered_in_error
+  }
+
+  public enum Purpose {
+    @JsonProperty("auth-requirements")
+    auth_requirements,
+    benefits,
+    discovery,
+    validation
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "CoverageEligibilityRequestSupportingInfo")
+  public static class SupportingInfo implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @NotBlank
+    @Pattern(regexp = Fhir.POSITIVE_INT)
+    String sequence;
+
+    @NotNull @Valid Reference information;
+
+    @Pattern(regexp = Fhir.BOOLEAN)
+    String appliesToAll;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "CoverageEligibilityRequestInsurance")
+  public static class Insurance implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @Pattern(regexp = Fhir.BOOLEAN)
+    String focal;
+
+    @NotNull @Valid Reference coverage;
+
+    @Pattern(regexp = Fhir.STRING)
+    String businessArrangement;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  @Schema(name = "CoverageEligibilityRequestItem")
+  public static class Item implements BackboneElement {
+
+    @Pattern(regexp = Fhir.ID)
+    String id;
+
+    @Valid List<Extension> extension;
+
+    @Valid List<Extension> modifierExtension;
+
+    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> supportingInfoSequence;
+
+    @Valid CodeableConcept category;
+
+    @Valid CodeableConcept productOrService;
+
+    @Valid List<CodeableConcept> modifier;
+
+    @Valid Reference provider;
+
+    @Valid SimpleQuantity quantity;
+
+    @Valid Money unitPrice;
+
+    @Valid Reference facility;
+
+    @Valid List<Diagnosis> diagnosis;
+
+    @Valid List<Reference> detail;
+
+    @Data
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @Schema(name = "CoverageEligibilityRequestItemDiagnosis")
+    @ZeroOrOneOf(
+      fields = {"diagnosisCodeableConcept", "diagnosisReference"},
+      message = "Only one diagnosis value may be specified."
+    )
+    public static class Diagnosis implements BackboneElement {
+
+      @Pattern(regexp = Fhir.ID)
+      String id;
+
+      @Valid List<Extension> extension;
+
+      @Valid List<Extension> modifierExtension;
+
+      @Valid CodeableConcept diagnosisCodeableConcept;
+
+      @Valid Reference diagnosisReference;
+    }
+  }
+}

--- a/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequest.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequest.java
@@ -183,7 +183,7 @@ public class CoverageEligibilityRequest implements Resource {
 
     @Valid List<Extension> modifierExtension;
 
-    @Valid List<@Pattern(regexp = Fhir.POSITIVE_INT) String> supportingInfoSequence;
+    List<@Pattern(regexp = Fhir.POSITIVE_INT) String> supportingInfoSequence;
 
     @Valid CodeableConcept category;
 

--- a/r4/src/test/java/gov/va/api/health/r4/api/AbstractRelatedFieldVerifier.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/AbstractRelatedFieldVerifier.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.r4.api.datatypes.Address;
+import gov.va.api.health.r4.api.datatypes.Attachment;
 import gov.va.api.health.r4.api.datatypes.CodeableConcept;
 import gov.va.api.health.r4.api.datatypes.Coding;
 import gov.va.api.health.r4.api.datatypes.ContactDetail;
@@ -100,6 +101,7 @@ public abstract class AbstractRelatedFieldVerifier<T> {
     SampleDataTypes dataTypes = SampleDataTypes.get();
     Map<Class<?>, Supplier<?>> suppliers = new HashMap<>();
     suppliers.put(Address.class, dataTypes::address);
+    suppliers.put(Attachment.class, dataTypes::attachment);
     suppliers.put(CodeableConcept.class, dataTypes::codeableConcept);
     suppliers.put(Coding.class, dataTypes::coding);
     suppliers.put(ContactDetail.class, dataTypes::contactDetail);

--- a/r4/src/test/java/gov/va/api/health/r4/api/resources/ClaimTest.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/resources/ClaimTest.java
@@ -1,0 +1,112 @@
+package gov.va.api.health.r4.api.resources;
+
+import static gov.va.api.health.r4.api.RoundTrip.assertRoundTrip;
+
+import gov.va.api.health.r4.api.ExactlyOneOfVerifier;
+import gov.va.api.health.r4.api.ZeroOrOneOfVerifier;
+import gov.va.api.health.r4.api.samples.SampleClaims;
+import org.junit.Test;
+
+public class ClaimTest {
+
+  private final SampleClaims data = SampleClaims.get();
+
+  @Test
+  public void testRelatedGroups() {
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.accidentWithLocationAddress())
+        .fieldPrefix("location")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.accidentWithLocationReference())
+        .fieldPrefix("location")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueAttachment())
+        .fieldPrefix("timing")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingPeriodAndValueAttachment())
+        .fieldPrefix("timing")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueAttachment())
+        .fieldPrefix("value")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueBoolean())
+        .fieldPrefix("value")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueQuantity())
+        .fieldPrefix("value")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueReference())
+        .fieldPrefix("value")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.supportingInfoWithTimingDateAndValueString())
+        .fieldPrefix("value")
+        .build()
+        .verify();
+    ExactlyOneOfVerifier.builder()
+        .sample(data.diagnosisWithCodeableConcept())
+        .fieldPrefix("diagnosis")
+        .build()
+        .verify();
+    ExactlyOneOfVerifier.builder()
+        .sample(data.diagnosisWithReference())
+        .fieldPrefix("diagnosis")
+        .build()
+        .verify();
+    ExactlyOneOfVerifier.builder()
+        .sample(data.procedureWithCodeableConcept())
+        .fieldPrefix("procedure")
+        .build()
+        .verify();
+    ExactlyOneOfVerifier.builder()
+        .sample(data.procedureWithReference())
+        .fieldPrefix("procedure")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.itemWithServicedDateAndLocationAddress())
+        .fieldPrefix("serviced")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.itemWithServicedPeriodAndLocationAddress())
+        .fieldPrefix("serviced")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.itemWithServicedDateAndLocationAddress())
+        .fieldPrefix("location")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.itemWithServicedDateAndLocationCodeableConcept())
+        .fieldPrefix("location")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.itemWithServicedDateAndLocationReference())
+        .fieldPrefix("location")
+        .build()
+        .verify();
+  }
+
+  @Test
+  public void testRoundTrip() {
+    assertRoundTrip(data.claim());
+  }
+}

--- a/r4/src/test/java/gov/va/api/health/r4/api/resources/ClaimTest.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/resources/ClaimTest.java
@@ -12,7 +12,12 @@ public class ClaimTest {
   private final SampleClaims data = SampleClaims.get();
 
   @Test
-  public void testRelatedGroups() {
+  public void claim() {
+    assertRoundTrip(data.claim());
+  }
+
+  @Test
+  public void relatedGroups() {
     ZeroOrOneOfVerifier.builder()
         .sample(data.accidentWithLocationAddress())
         .fieldPrefix("location")
@@ -103,10 +108,5 @@ public class ClaimTest {
         .fieldPrefix("location")
         .build()
         .verify();
-  }
-
-  @Test
-  public void testRoundTrip() {
-    assertRoundTrip(data.claim());
   }
 }

--- a/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequestTest.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequestTest.java
@@ -11,7 +11,7 @@ public class CoverageEligibilityRequestTest {
   private final SampleCoverageEligibilityRequests data = SampleCoverageEligibilityRequests.get();
 
   @Test
-  public void coverageEligibilityResponse() {
+  public void coverageEligibilityRequest() {
     assertRoundTrip(data.coverageEligibilityRequest());
   }
 

--- a/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequestTest.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/resources/CoverageEligibilityRequestTest.java
@@ -1,0 +1,41 @@
+package gov.va.api.health.r4.api.resources;
+
+import static gov.va.api.health.r4.api.RoundTrip.assertRoundTrip;
+
+import gov.va.api.health.r4.api.ZeroOrOneOfVerifier;
+import gov.va.api.health.r4.api.samples.SampleCoverageEligibilityRequests;
+import org.junit.Test;
+
+public class CoverageEligibilityRequestTest {
+
+  private final SampleCoverageEligibilityRequests data = SampleCoverageEligibilityRequests.get();
+
+  @Test
+  public void coverageEligibilityResponse() {
+    assertRoundTrip(data.coverageEligibilityRequest());
+  }
+
+  @Test
+  public void relatedGroups() {
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.diagnosisWithCodeableConcept())
+        .fieldPrefix("diagnosis")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.diagnosisWithReference())
+        .fieldPrefix("diagnosis")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.coverageEligibilityRequestWithServicedDate())
+        .fieldPrefix("serviced")
+        .build()
+        .verify();
+    ZeroOrOneOfVerifier.builder()
+        .sample(data.coverageEligibilityRequestWithServicedPeriod())
+        .fieldPrefix("serviced")
+        .build()
+        .verify();
+  }
+}

--- a/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleClaims.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleClaims.java
@@ -157,7 +157,7 @@ public class SampleClaims {
   private Procedure incompleteProcedure() {
     return Procedure.builder()
         .sequence("1")
-        .type(codeableConcept())
+        .type(singletonList(codeableConcept()))
         .date("2017-01-01T00:00:00.000Z")
         .udi(singletonList(reference()))
         .build();

--- a/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleClaims.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleClaims.java
@@ -1,0 +1,324 @@
+package gov.va.api.health.r4.api.samples;
+
+import static java.util.Collections.singletonList;
+
+import gov.va.api.health.r4.api.resources.Claim;
+import gov.va.api.health.r4.api.resources.Claim.Accident;
+import gov.va.api.health.r4.api.resources.Claim.CareTeam;
+import gov.va.api.health.r4.api.resources.Claim.Diagnosis;
+import gov.va.api.health.r4.api.resources.Claim.Insurance;
+import gov.va.api.health.r4.api.resources.Claim.Item;
+import gov.va.api.health.r4.api.resources.Claim.Item.Detail;
+import gov.va.api.health.r4.api.resources.Claim.Item.Detail.SubDetail;
+import gov.va.api.health.r4.api.resources.Claim.Payee;
+import gov.va.api.health.r4.api.resources.Claim.Procedure;
+import gov.va.api.health.r4.api.resources.Claim.Related;
+import gov.va.api.health.r4.api.resources.Claim.Status;
+import gov.va.api.health.r4.api.resources.Claim.SupportingInfo;
+import gov.va.api.health.r4.api.resources.Claim.Use;
+import java.util.Arrays;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Delegate;
+
+@NoArgsConstructor(staticName = "get")
+public class SampleClaims {
+
+  @Delegate SampleDataTypes dataTypes = SampleDataTypes.get();
+
+  /*
+   * Accident is missing optional 0..1 location[x] field
+   */
+  public Accident accident() {
+    return Accident.builder().date("1905-08-23").type(codeableConcept()).build();
+  }
+
+  public Accident accidentWithLocationAddress() {
+    return accident().locationAddress(address());
+  }
+
+  public Accident accidentWithLocationReference() {
+    return accident().locationReference(reference());
+  }
+
+  public CareTeam careTeam() {
+    return CareTeam.builder()
+        .sequence("1")
+        .provider(reference())
+        .responsible("true")
+        .role(codeableConcept())
+        .qualification(codeableConcept())
+        .build();
+  }
+
+  public Claim claim() {
+    return Claim.builder()
+        .id("1234")
+        .resourceType("Claim")
+        .meta(meta())
+        .implicitRules("https://HelloRules.com")
+        .language("Hello language")
+        .text(narrative())
+        .contained(singletonList(resource()))
+        .extension(Arrays.asList(extension(), extension()))
+        .modifierExtension(
+            Arrays.asList(extension(), extensionWithQuantity(), extensionWithRatio()))
+        .identifier(singletonList(identifier()))
+        .status(Status.active)
+        .type(codeableConcept())
+        .subType(codeableConcept())
+        .use(Use.claim)
+        .patient(reference())
+        .billablePeriod(period())
+        .created("2017-01-01T00:00:00.000Z")
+        .enterer(reference())
+        .insurer(reference())
+        .provider(reference())
+        .priority(codeableConcept())
+        .fundsReserve(codeableConcept())
+        .related(singletonList(related()))
+        .prescription(reference())
+        .originalPrescription(reference())
+        .payee(payee())
+        .referral(reference())
+        .facility(reference())
+        .careTeam(singletonList(careTeam()))
+        .supportingInfo(
+            Arrays.asList(
+                supportingInfo(),
+                supportingInfoWithTimingDate(),
+                supportingInfoWithTimingDateAndValueAttachment(),
+                supportingInfoWithTimingDateAndValueQuantity(),
+                supportingInfoWithTimingDateAndValueReference(),
+                supportingInfoWithTimingDateAndValueString(),
+                supportingInfoWithTimingDateAndValueBoolean(),
+                supportingInfoWithTimingPeriod(),
+                supportingInfoWithTimingPeriodAndValueAttachment(),
+                supportingInfoWithTimingPeriodAndValueQuantity(),
+                supportingInfoWithTimingPeriodAndValueReference(),
+                supportingInfoWithTimingPeriodAndValueString(),
+                supportingInfoWithTimingPeriodAndValueBoolean()))
+        .diagnosis(Arrays.asList(diagnosisWithCodeableConcept(), diagnosisWithReference()))
+        .procedure(Arrays.asList(procedureWithCodeableConcept(), procedureWithReference()))
+        .insurance(singletonList(insurance()))
+        .accident(accidentWithLocationAddress())
+        .item(
+            Arrays.asList(
+                item(),
+                itemWithServicedDateAndLocationAddress(),
+                itemWithServicedDateAndLocationCodeableConcept(),
+                itemWithServicedDateAndLocationReference(),
+                itemWithServicedPeriodAndLocationAddress(),
+                itemWithServicedPeriodAndLocationCodeableConcept(),
+                itemWithServicedPeriodAndLocationReference()))
+        .total(money())
+        .build();
+  }
+
+  public Detail detail() {
+    return Detail.builder()
+        .sequence("1")
+        .revenue(codeableConcept())
+        .category(codeableConcept())
+        .productOrService(codeableConcept())
+        .modifier(singletonList(codeableConcept()))
+        .programCode(singletonList(codeableConcept()))
+        .quantity(simpleQuantity())
+        .unitPrice(money())
+        .factor("1.0")
+        .net(money())
+        .udi(singletonList(reference()))
+        .subDetail(singletonList(subDetail()))
+        .build();
+  }
+
+  public Diagnosis diagnosisWithCodeableConcept() {
+    return incompleteDiagnosis().diagnosisCodeableConcept(codeableConcept());
+  }
+
+  public Diagnosis diagnosisWithReference() {
+    return incompleteDiagnosis().diagnosisReference(reference());
+  }
+
+  /*
+   * Diagnosis is missing required 1..1 diagnosis[x] field
+   */
+  private Diagnosis incompleteDiagnosis() {
+    return Diagnosis.builder()
+        .sequence("1")
+        .type(singletonList(codeableConcept()))
+        .onAdmission(codeableConcept())
+        .packageCode(codeableConcept())
+        .build();
+  }
+
+  /*
+   * Procedure is missing required 1..1 procedure[x] field
+   */
+  private Procedure incompleteProcedure() {
+    return Procedure.builder()
+        .sequence("1")
+        .type(codeableConcept())
+        .date("2017-01-01T00:00:00.000Z")
+        .udi(singletonList(reference()))
+        .build();
+  }
+
+  public Insurance insurance() {
+    return Insurance.builder()
+        .sequence("1")
+        .focal("true")
+        .identifier(identifier())
+        .coverage(reference())
+        .businessArrangement("business arrangement")
+        .preAuthRef(singletonList("pre auth ref"))
+        .claimResponse(reference())
+        .build();
+  }
+
+  /*
+   * Item is missing optional serviced[x] and location[x] fields
+   */
+  public Item item() {
+    return Item.builder()
+        .sequence("1")
+        .careTeamSequence(singletonList("1"))
+        .diagnosisSequence(singletonList("1"))
+        .procedureSequence(singletonList("1"))
+        .informationSequence(singletonList("1"))
+        .revenue(codeableConcept())
+        .category(codeableConcept())
+        .productOrService(codeableConcept())
+        .modifier(singletonList(codeableConcept()))
+        .programCode(singletonList(codeableConcept()))
+        .quantity(simpleQuantity())
+        .unitPrice(money())
+        .factor("1.0")
+        .net(money())
+        .udi(singletonList(reference()))
+        .bodySite(codeableConcept())
+        .subSite(singletonList(codeableConcept()))
+        .encounter(singletonList(reference()))
+        .detail(singletonList(detail()))
+        .build();
+  }
+
+  public Item itemWithServicedDateAndLocationAddress() {
+    return item().servicedDate("1905-08-23").locationAddress(address());
+  }
+
+  public Item itemWithServicedDateAndLocationCodeableConcept() {
+    return item().servicedDate("1905-08-23").locationCodeableConcept(codeableConcept());
+  }
+
+  public Item itemWithServicedDateAndLocationReference() {
+    return item().servicedDate("1905-08-23").locationReference(reference());
+  }
+
+  public Item itemWithServicedPeriodAndLocationAddress() {
+    return item().servicedPeriod(period()).locationAddress(address());
+  }
+
+  public Item itemWithServicedPeriodAndLocationCodeableConcept() {
+    return item().servicedPeriod(period()).locationCodeableConcept(codeableConcept());
+  }
+
+  public Item itemWithServicedPeriodAndLocationReference() {
+    return item().servicedPeriod(period()).locationReference(reference());
+  }
+
+  public Payee payee() {
+    return Payee.builder().type(codeableConcept()).party(reference()).build();
+  }
+
+  public Procedure procedureWithCodeableConcept() {
+    return incompleteProcedure().procedureCodeableConcept(codeableConcept());
+  }
+
+  public Procedure procedureWithReference() {
+    return incompleteProcedure().procedureReference(reference());
+  }
+
+  public Related related() {
+    return Related.builder()
+        .claim(reference())
+        .relationship(codeableConcept())
+        .reference(identifier())
+        .build();
+  }
+
+  public SubDetail subDetail() {
+    return SubDetail.builder()
+        .sequence("1")
+        .revenue(codeableConcept())
+        .category(codeableConcept())
+        .productOrService(codeableConcept())
+        .modifier(singletonList(codeableConcept()))
+        .programCode(singletonList(codeableConcept()))
+        .quantity(simpleQuantity())
+        .unitPrice(money())
+        .factor("1.0")
+        .net(money())
+        .udi(singletonList(reference()))
+        .build();
+  }
+
+  /*
+   * SupportingInfo is missing optional 0..1 timing[x] and 0..1 value[x] fields
+   */
+  public SupportingInfo supportingInfo() {
+    return SupportingInfo.builder()
+        .sequence("1")
+        .category(codeableConcept())
+        .code(codeableConcept())
+        .reason(codeableConcept())
+        .build();
+  }
+
+  public SupportingInfo supportingInfoWithTimingDate() {
+    return supportingInfo().timingDate("1905-08-23");
+  }
+
+  public SupportingInfo supportingInfoWithTimingDateAndValueAttachment() {
+    return supportingInfoWithTimingDate().valueAttachment(attachment());
+  }
+
+  public SupportingInfo supportingInfoWithTimingDateAndValueBoolean() {
+    return supportingInfoWithTimingDate().valueBoolean("true");
+  }
+
+  public SupportingInfo supportingInfoWithTimingDateAndValueQuantity() {
+    return supportingInfoWithTimingDate().valueQuantity(quantity());
+  }
+
+  public SupportingInfo supportingInfoWithTimingDateAndValueReference() {
+    return supportingInfoWithTimingDate().valueReference(reference());
+  }
+
+  public SupportingInfo supportingInfoWithTimingDateAndValueString() {
+    return supportingInfoWithTimingDate().valueString("value");
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriod() {
+    return supportingInfo().timingPeriod(period());
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriodAndValueAttachment() {
+    return supportingInfoWithTimingPeriod().valueAttachment(attachment());
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriodAndValueBoolean() {
+    return supportingInfoWithTimingPeriod().valueBoolean("true");
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriodAndValueQuantity() {
+    return supportingInfoWithTimingPeriod().valueQuantity(quantity());
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriodAndValueReference() {
+    return supportingInfoWithTimingPeriod().valueReference(reference());
+  }
+
+  public SupportingInfo supportingInfoWithTimingPeriodAndValueString() {
+    return supportingInfoWithTimingPeriod().valueString("value");
+  }
+}

--- a/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleCoverageEligibilityRequests.java
+++ b/r4/src/test/java/gov/va/api/health/r4/api/samples/SampleCoverageEligibilityRequests.java
@@ -1,0 +1,95 @@
+package gov.va.api.health.r4.api.samples;
+
+import static java.util.Collections.singletonList;
+
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.Insurance;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.Item;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.Item.Diagnosis;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.Purpose;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.Status;
+import gov.va.api.health.r4.api.resources.CoverageEligibilityRequest.SupportingInfo;
+import java.util.Arrays;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Delegate;
+
+@NoArgsConstructor(staticName = "get")
+public class SampleCoverageEligibilityRequests {
+
+  @Delegate SampleDataTypes dataTypes = SampleDataTypes.get();
+
+  public CoverageEligibilityRequest coverageEligibilityRequest() {
+    return CoverageEligibilityRequest.builder()
+        .id("1234")
+        .resourceType("CoverageEligibilityRequest")
+        .meta(meta())
+        .implicitRules("https://HelloRules.com")
+        .language("Hello language")
+        .text(narrative())
+        .contained(singletonList(resource()))
+        .extension(Arrays.asList(extension(), extension()))
+        .modifierExtension(
+            Arrays.asList(extension(), extensionWithQuantity(), extensionWithRatio()))
+        .identifier(singletonList(identifier()))
+        .status(Status.active)
+        .priority(codeableConcept())
+        .purpose(singletonList(Purpose.auth_requirements))
+        .patient(reference())
+        .created("2017-01-01T00:00:00.000Z")
+        .enterer(reference())
+        .provider(reference())
+        .insurer(reference())
+        .facility(reference())
+        .supportingInfo(singletonList(supportingInfo()))
+        .insurance(singletonList(insurance()))
+        .item(singletonList(item()))
+        .build();
+  }
+
+  public CoverageEligibilityRequest coverageEligibilityRequestWithServicedDate() {
+    return coverageEligibilityRequest().servicedDate("1905-08-23");
+  }
+
+  public CoverageEligibilityRequest coverageEligibilityRequestWithServicedPeriod() {
+    return coverageEligibilityRequest().servicedPeriod(period());
+  }
+
+  public Diagnosis diagnosisWithCodeableConcept() {
+    return Diagnosis.builder().diagnosisCodeableConcept(codeableConcept()).build();
+  }
+
+  public Diagnosis diagnosisWithReference() {
+    return Diagnosis.builder().diagnosisReference(reference()).build();
+  }
+
+  public Insurance insurance() {
+    return Insurance.builder()
+        .focal("true")
+        .coverage(reference())
+        .businessArrangement("businessArrangement")
+        .build();
+  }
+
+  public Item item() {
+    return Item.builder()
+        .supportingInfoSequence(singletonList("1"))
+        .category(codeableConcept())
+        .productOrService(codeableConcept())
+        .modifier(singletonList(codeableConcept()))
+        .provider(reference())
+        .quantity(simpleQuantity())
+        .unitPrice(money())
+        .facility(reference())
+        .diagnosis(Arrays.asList(diagnosisWithCodeableConcept(), diagnosisWithReference()))
+        .detail(singletonList(reference()))
+        .build();
+  }
+
+  public SupportingInfo supportingInfo() {
+    return SupportingInfo.builder()
+        .sequence("1")
+        .information(reference())
+        .appliesToAll("true")
+        .build();
+  }
+}


### PR DESCRIPTION
Added models for `Claim` and `CoverageEligibilityRequest`, following the existing models as templates.

https://www.hl7.org/fhir/claim.html
https://www.hl7.org/fhir/coverageeligibilityrequest.html

This makes no attempt to define an API, it only makes the models available for future use.

Please identify any downstream resources beyond my knowledge that may be affected by these changes.