### PR TITLE
API 822 unify common

### DIFF
--- a/dstu2/pom.xml
+++ b/dstu2/pom.xml
@@ -19,5 +19,10 @@
       <artifactId>validation</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>gov.va.api.health</groupId>
+      <artifactId>fhir-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/dstu2/src/main/java/gov/va/api/health/dstu2/api/Fhir.java
+++ b/dstu2/src/main/java/gov/va/api/health/dstu2/api/Fhir.java
@@ -1,12 +1,11 @@
 package gov.va.api.health.dstu2.api;
 
+import gov.va.api.health.fhir.api.FhirDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import javax.xml.datatype.DatatypeFactory;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Fhir {
@@ -54,18 +53,10 @@ public class Fhir {
 
   public static final String XHTML = "<.+>";
 
-  /**
-   * Attempt to parse the given dateTime string. Returns null if the given string is null or empty,
-   * throws a IllegalArgumentException if the date cannot be parsed, otherwise returns an Instant.
-   */
+  /** Deprecated: Use gov.va.api.health.fhir.api.FhirDateTime#parseDateTime(java.lang.String). */
   @SneakyThrows
+  @Deprecated
   public static Instant parseDateTime(String dateTime) {
-    if (StringUtils.isBlank(dateTime)) {
-      return null;
-    }
-    return DatatypeFactory.newInstance()
-        .newXMLGregorianCalendar(dateTime)
-        .toGregorianCalendar()
-        .toInstant();
+    return FhirDateTime.parseDateTime(dateTime);
   }
 }

--- a/dstu2/src/main/java/gov/va/api/health/dstu2/api/elements/Reference.java
+++ b/dstu2/src/main/java/gov/va/api/health/dstu2/api/elements/Reference.java
@@ -2,6 +2,7 @@ package gov.va.api.health.dstu2.api.elements;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import gov.va.api.health.dstu2.api.Fhir;
+import gov.va.api.health.fhir.api.IsReference;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.Valid;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Schema(description = "http://hl7.org/fhir/DSTU2/references.html")
-public class Reference implements Element {
+public class Reference implements Element, IsReference {
   @Pattern(regexp = Fhir.ID)
   String id;
 

--- a/dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationDispense.java
+++ b/dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationDispense.java
@@ -21,6 +21,7 @@ import gov.va.api.health.dstu2.api.elements.Extension;
 import gov.va.api.health.dstu2.api.elements.Meta;
 import gov.va.api.health.dstu2.api.elements.Narrative;
 import gov.va.api.health.dstu2.api.elements.Reference;
+import gov.va.api.health.fhir.api.FhirDateTime;
 import gov.va.api.health.validation.api.ExactlyOneOf;
 import gov.va.api.health.validation.api.ZeroOrOneOf;
 import gov.va.api.health.validation.api.ZeroOrOneOfs;
@@ -114,8 +115,8 @@ public class MedicationDispense implements DomainResource {
      * to be the only one thrown instead of this one with a more generic message.
      */
     try {
-      Instant prepared = Fhir.parseDateTime(whenPrepared);
-      Instant handedOver = Fhir.parseDateTime(whenHandedOver);
+      Instant prepared = FhirDateTime.parseDateTime(whenPrepared);
+      Instant handedOver = FhirDateTime.parseDateTime(whenHandedOver);
       return !prepared.isAfter(handedOver);
     } catch (IllegalArgumentException e) {
       /*

--- a/fhir-common/pom.xml
+++ b/fhir-common/pom.xml
@@ -1,26 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>api-starter</artifactId>
     <groupId>gov.va.api.health</groupId>
     <version>6.0.6</version>
     <relativePath/>
   </parent>
-  <artifactId>us-core-r4</artifactId>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>fhir-common</artifactId>
   <version>2.0.37-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <properties/>
-  <dependencies>
-    <dependency>
-      <groupId>gov.va.api.health</groupId>
-      <artifactId>r4</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>gov.va.api.health</groupId>
-      <artifactId>fhir-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/fhir-common/spotbugs-excludes.xml
+++ b/fhir-common/spotbugs-excludes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <!-- Exclusions can be defined here and should include a comment on why the finding can be ignored -->
+</FindBugsFilter>

--- a/fhir-common/src/main/java/gov/va/api/health/fhir/api/FhirDateTime.java
+++ b/fhir-common/src/main/java/gov/va/api/health/fhir/api/FhirDateTime.java
@@ -1,0 +1,26 @@
+package gov.va.api.health.fhir.api;
+
+import java.time.Instant;
+import javax.xml.datatype.DatatypeFactory;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FhirDateTime {
+  /**
+   * Attempt to parse the given dateTime string. Returns null if the given string is null or empty,
+   * throws a IllegalArgumentException if the date cannot be parsed, otherwise returns an Instant.
+   */
+  @SneakyThrows
+  public static Instant parseDateTime(String dateTime) {
+    if (StringUtils.isBlank(dateTime)) {
+      return null;
+    }
+    return DatatypeFactory.newInstance()
+        .newXMLGregorianCalendar(dateTime)
+        .toGregorianCalendar()
+        .toInstant();
+  }
+}

--- a/fhir-common/src/main/java/gov/va/api/health/fhir/api/IsReference.java
+++ b/fhir-common/src/main/java/gov/va/api/health/fhir/api/IsReference.java
@@ -1,0 +1,19 @@
+package gov.va.api.health.fhir.api;
+
+/**
+ * This common set of attributes across DSTU2, STU3, and R4 reference is used for processing that
+ * spans all versions of FHIR.
+ */
+public interface IsReference {
+  String display();
+
+  IsReference display(String display);
+
+  String id();
+
+  IsReference id(String id);
+
+  String reference();
+
+  IsReference reference(String reference);
+}

--- a/fhir-common/src/test/java/gov/va/api/health/fhir/api/FhirDateTimeTest.java
+++ b/fhir-common/src/test/java/gov/va/api/health/fhir/api/FhirDateTimeTest.java
@@ -1,0 +1,57 @@
+package gov.va.api.health.fhir.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class FhirDateTimeTest {
+  /**
+   * Datetime is a union of xs:dateTime, xs:date, xs:gYearMonth, xs:gYear. See
+   * http://hl7.org/fhir/DSTU2/datatypes.html#datetime
+   */
+  @Test
+  public void parseDateTime() {
+    assertThat(FhirDateTime.parseDateTime(null)).isNull();
+    assertThat(FhirDateTime.parseDateTime(" ")).isNull();
+    for (String datetime :
+        Arrays.asList(
+            // dateTime
+            "2002-05-30T09:00:00",
+            "2002-05-30T09:30:10.5",
+            "2002-05-30T09:30:10Z",
+            "2002-05-30T09:30:10-06:00",
+            "2002-05-30T09:30:10+06:00",
+            // date
+            "2002-09-24",
+            "2002-09-24Z",
+            "2002-09-24-06:00",
+            "2002-09-24+06:00",
+            // gYearMonth
+            "2001-10",
+            "2001-10+02:00",
+            "2001-10Z",
+            "2001-10+00:00",
+            "-2001-10",
+            "-20000-04",
+            // gYear
+            "2001",
+            "2001+02:00",
+            "2001Z",
+            "2001+00:00",
+            "-2001",
+            "-20000"
+            //
+            )) {
+      Instant actual = FhirDateTime.parseDateTime(datetime);
+      assertThat(actual).withFailMessage(datetime).isNotNull();
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseDateTimeThrowsExceptionWhenCannotBeParsed() {
+    FhirDateTime.parseDateTime("nope");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <version>2.0.37-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
+    <module>fhir-common</module>
     <module>validation</module>
     <module>r4</module>
     <module>r4-examples</module>

--- a/r4/pom.xml
+++ b/r4/pom.xml
@@ -19,5 +19,10 @@
       <artifactId>validation</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>gov.va.api.health</groupId>
+      <artifactId>fhir-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/r4/src/main/java/gov/va/api/health/r4/api/Fhir.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/Fhir.java
@@ -1,12 +1,11 @@
 package gov.va.api.health.r4.api;
 
+import gov.va.api.health.fhir.api.FhirDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import javax.xml.datatype.DatatypeFactory;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Fhir {
@@ -81,18 +80,10 @@ public class Fhir {
   @Schema(description = "https://www.hl7.org/fhir/R4/datatypes.html#integer")
   public static final String INTEGER = "[0]|[-+]?[1-9][0-9]*";
 
-  /**
-   * Attempt to parse the given dateTime string. Returns null if the given string is null or empty,
-   * throws a IllegalArgumentException if the date cannot be parsed, otherwise returns an Instant.
-   */
+  /** Deprecated: Use gov.va.api.health.fhir.api.FhirDateTime#parseDateTime(java.lang.String). */
   @SneakyThrows
+  @Deprecated
   public static Instant parseDateTime(String dateTime) {
-    if (StringUtils.isBlank(dateTime)) {
-      return null;
-    }
-    return DatatypeFactory.newInstance()
-        .newXMLGregorianCalendar(dateTime)
-        .toGregorianCalendar()
-        .toInstant();
+    return FhirDateTime.parseDateTime(dateTime);
   }
 }

--- a/r4/src/main/java/gov/va/api/health/r4/api/elements/Reference.java
+++ b/r4/src/main/java/gov/va/api/health/r4/api/elements/Reference.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.r4.api.elements;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import gov.va.api.health.fhir.api.IsReference;
 import gov.va.api.health.r4.api.Fhir;
 import gov.va.api.health.r4.api.datatypes.Identifier;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Schema(description = "https://www.hl7.org/fhir/R4/references.html")
-public class Reference implements Element {
+public class Reference implements Element, IsReference {
   @Pattern(regexp = Fhir.ID)
   String id;
 

--- a/stu3/pom.xml
+++ b/stu3/pom.xml
@@ -16,5 +16,10 @@
       <artifactId>validation</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>gov.va.api.health</groupId>
+      <artifactId>fhir-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/stu3/src/main/java/gov/va/api/health/stu3/api/Fhir.java
+++ b/stu3/src/main/java/gov/va/api/health/stu3/api/Fhir.java
@@ -1,12 +1,11 @@
 package gov.va.api.health.stu3.api;
 
+import gov.va.api.health.fhir.api.FhirDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
-import javax.xml.datatype.DatatypeFactory;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Fhir {
@@ -54,18 +53,10 @@ public class Fhir {
 
   public static final String XHTML = "<.+>";
 
-  /**
-   * Attempt to parse the given dateTime string. Returns null if the given string is null or empty,
-   * throws a IllegalArgumentException if the date cannot be parsed, otherwise returns an Instant.
-   */
+  /** Deprecated: Use gov.va.api.health.fhir.api.FhirDateTime#parseDateTime(java.lang.String). */
   @SneakyThrows
+  @Deprecated
   public static Instant parseDateTime(String dateTime) {
-    if (StringUtils.isBlank(dateTime)) {
-      return null;
-    }
-    return DatatypeFactory.newInstance()
-        .newXMLGregorianCalendar(dateTime)
-        .toGregorianCalendar()
-        .toInstant();
+    return FhirDateTime.parseDateTime(dateTime);
   }
 }

--- a/stu3/src/main/java/gov/va/api/health/stu3/api/elements/Reference.java
+++ b/stu3/src/main/java/gov/va/api/health/stu3/api/elements/Reference.java
@@ -1,6 +1,7 @@
 package gov.va.api.health.stu3.api.elements;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import gov.va.api.health.fhir.api.IsReference;
 import gov.va.api.health.stu3.api.Fhir;
 import gov.va.api.health.stu3.api.datatypes.Identifier;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Schema(description = "http://hl7.org/fhir/STU3/references.html")
-public class Reference implements Element {
+public class Reference implements Element, IsReference {
   @Pattern(regexp = Fhir.ID)
   String id;
 


### PR DESCRIPTION
To support modules that can process dstu2, stu3, and r4 references the same, this introduces
- an  IsReference interface
- a new fhir-common module with standardized date time parsing
