### PR TITLE
API-1028-fix-medication-request-swagger-text

### DIFF
--- a/us-core-r4/src/main/java/gov/va/api/health/uscorer4/api/resources/MedicationRequest.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/uscorer4/api/resources/MedicationRequest.java
@@ -205,7 +205,7 @@ public class MedicationRequest implements Resource {
       name = "MedicationRequestBundle",
       example =
           "${uscorer4.medicationRequestBundle:gov.va.api.health."
-              + "uscorer4.api.swaggerexamples.SwaggerMedicationRequest#medicatinRequestBundle}")
+              + "uscorer4.api.swaggerexamples.SwaggerMedicationRequest#medicationRequestBundle}")
   public static class Bundle extends AbstractBundle<MedicationRequest.Entry> {
 
     /** Build a Medication Request bundle. */


### PR DESCRIPTION
Fixed mis-spelled swagger example for bundle.