### PR TITLE
API-5974 Fix for Extension

### DIFF
--- a/us-core-r4/src/main/java/gov/va/api/health/r4/api/datatypes/Coding.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/r4/api/datatypes/Coding.java
@@ -9,6 +9,7 @@ import gov.va.api.health.r4.api.elements.Element;
 import gov.va.api.health.r4.api.elements.Extension;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,7 +24,7 @@ public class Coding implements Element, HasDisplay {
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  List<Extension> extension;
+  @Valid List<Extension> extension;
 
   @Pattern(regexp = Fhir.URI)
   String system;

--- a/us-core-r4/src/main/java/gov/va/api/health/r4/api/elements/Meta.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/r4/api/elements/Meta.java
@@ -23,7 +23,7 @@ public class Meta implements Element {
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @Valid List<Extension> extension;
+  List<@Valid Extension> extension;
 
   @Pattern(regexp = Fhir.ID)
   String versionId;


### PR DESCRIPTION
This change adds a workaround for an existing bug in the swagger openapi definition json generator.

The bug is ultimately triggered by schemas containing a collection of its self type. In this case, the Extension element:
```
class Extension {
   ...
   @Valid List<Extension> extension; // 
   ...
}
```

Depending on the order that the schemas are processed by swagger's Model Converters, the `extension` property is missing on many properties in the outputted json. The field's annotations also seem to affect this behavior.

In both DQ and SC, the `Meta` element is the first element (by chance) that is processed which contains a `@Valid List<Extension>`. By moving the annotation to `List<@Valid Extension>`, the bug can be avoided.

We're just subtly changing the signature of the property in the initial pass so swagger is forced to re-resolve it the next time it sees it.

I'll open a bug report with swagger-api to hopefully get this fixed in a future release.