### PR TITLE
Add identifier search param to practitioner swagger

### DIFF
--- a/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
@@ -88,7 +88,7 @@ public interface PractitionerApi {
       @Parameter(
               in = ParameterIn.PATH,
               name = "identifier",
-              description = "An identifier uniquely identifies one object/resource.")
+              description = "A unique identifier for a practitioner within a given system.")
           String identifier,
       @Parameter(
               in = ParameterIn.QUERY,

--- a/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
@@ -88,11 +88,7 @@ public interface PractitionerApi {
       @Parameter(
               in = ParameterIn.PATH,
               name = "identifier",
-              description =
-                  "The logical identifier of the resource."
-                      + " Once assigned, this value never changes."
-                      + " For Practitioners this identifier is the"
-                      + " National Provider Identifier (NPI).")
+              description = "An identifier uniquely identifies one object/resource.")
           String identifier,
       @Parameter(
               in = ParameterIn.QUERY,

--- a/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
+++ b/us-core-r4/src/main/java/gov/va/api/health/r4/api/PractitionerApi.java
@@ -86,6 +86,15 @@ public interface PractitionerApi {
                   "The logical id of the resource. Once assigned, this value never changes.")
           String id,
       @Parameter(
+              in = ParameterIn.PATH,
+              name = "identifier",
+              description =
+                  "The logical identifier of the resource."
+                      + " Once assigned, this value never changes."
+                      + " For Practitioners this identifier is the"
+                      + " National Provider Identifier (NPI).")
+          String identifier,
+      @Parameter(
               in = ParameterIn.QUERY,
               name = "page",
               description = "The page number of the search result.")


### PR DESCRIPTION
Practitioner identifier search allows for NPI searches.