### PR TITLE
API-7924 default resource types

### DIFF
--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAllergyIntolerance.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAllergyIntolerance.java
@@ -14,7 +14,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.AllergyIntolerance;
 
 public class SwaggerAllergyIntolerance {
-
   /**
    * An example AllergyIntolerance.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAllergyIntolerance.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAllergyIntolerance.java
@@ -22,7 +22,6 @@ public class SwaggerAllergyIntolerance {
    */
   public static AllergyIntolerance allergyIntolerance() {
     return AllergyIntolerance.builder()
-        .resourceType("AllergyIntolerance")
         .id("6f9a021b-07d5-53c8-8cce-b49a694d4ad9")
         .onset("1995-04-30T01:15:52Z")
         .patient(
@@ -62,7 +61,6 @@ public class SwaggerAllergyIntolerance {
    */
   public static AllergyIntolerance.Bundle allergyIntoleranceBundle() {
     return AllergyIntolerance.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -89,7 +87,6 @@ public class SwaggerAllergyIntolerance {
                         "https://sandbox-api.va.gov/services/argonaut/v0/AllergyIntolerance/6f9a021b-07d5-53c8-8cce-b49a694d4ad9")
                     .resource(
                         AllergyIntolerance.builder()
-                            .resourceType("AllergyIntolerance")
                             .id("e2019e0c-fa38-596d-b966-9b86926959a7")
                             .onset("1995-04-30T01:15:52Z")
                             .patient(

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAppointment.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAppointment.java
@@ -21,7 +21,6 @@ public class SwaggerAppointment {
    */
   public static Appointment appointment() {
     return Appointment.builder()
-        .resourceType("Appointment")
         .id("0be173b4-721c-554e-ba7d-966d04633b68")
         .status(Appointment.Status.cancelled)
         .description("Scheduled Visit")
@@ -80,7 +79,6 @@ public class SwaggerAppointment {
    */
   public static Appointment.Bundle appointmentBundle() {
     return Appointment.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -107,7 +105,6 @@ public class SwaggerAppointment {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Appointment/0be173b4-721c-554e-ba7d-966d04633b68")
                     .resource(
                         Appointment.builder()
-                            .resourceType("Appointment")
                             .id("0be173b4-721c-554e-ba7d-966d04633b68")
                             .status(Appointment.Status.cancelled)
                             .description("Scheduled Visit")

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAppointment.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerAppointment.java
@@ -13,7 +13,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Appointment;
 
 public class SwaggerAppointment {
-
   /**
    * An example Appointment.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerCondition.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerCondition.java
@@ -21,7 +21,6 @@ public class SwaggerCondition {
    */
   public static Condition condition() {
     return Condition.builder()
-        .resourceType("Condition")
         .id("b34bacd3-42b6-5613-b1c2-1abafe1248ba")
         .patient(
             Reference.builder()
@@ -59,7 +58,6 @@ public class SwaggerCondition {
    */
   public static Condition.Bundle conditionBundle() {
     return Condition.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -86,7 +84,6 @@ public class SwaggerCondition {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Condition/b34bacd3-42b6-5613-b1c2-1abafe1248ba")
                     .resource(
                         Condition.builder()
-                            .resourceType("Condition")
                             .id("b34bacd3-42b6-5613-b1c2-1abafe1248ba")
                             .patient(
                                 Reference.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerCondition.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerCondition.java
@@ -13,7 +13,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Condition;
 
 public class SwaggerCondition {
-
   /**
    * An example Condition.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerDiagnosticReport.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerDiagnosticReport.java
@@ -13,7 +13,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.DiagnosticReport;
 
 public class SwaggerDiagnosticReport {
-
   /**
    * An example DiagnosticReport.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerDiagnosticReport.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerDiagnosticReport.java
@@ -21,7 +21,6 @@ public class SwaggerDiagnosticReport {
    */
   public static final DiagnosticReport diagnosticReport() {
     return DiagnosticReport.builder()
-        .resourceType("DiagnosticReport")
         .id("0757389a-6e06-51bd-aac0-bd0244e51e46")
         .status(DiagnosticReport.Code._final)
         .category(
@@ -52,7 +51,6 @@ public class SwaggerDiagnosticReport {
    */
   public static final DiagnosticReport.Bundle diagnosticReportBundle() {
     return DiagnosticReport.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -79,7 +77,6 @@ public class SwaggerDiagnosticReport {
                         "https://sandbox-api.va.gov/services/argonaut/v0/DiagnosticReport/0757389a-6e06-51bd-aac0-bd0244e51e46")
                     .resource(
                         DiagnosticReport.builder()
-                            .resourceType("DiagnosticReport")
                             .id("0757389a-6e06-51bd-aac0-bd0244e51e46")
                             .status(DiagnosticReport.Code._final)
                             .category(

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerEncounter.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerEncounter.java
@@ -18,7 +18,6 @@ public class SwaggerEncounter {
    */
   public static Encounter encounter() {
     return Encounter.builder()
-        .resourceType("Encounter")
         .id("dc7f6fcc-41f9-5be9-a364-0b0aa938917a")
         .status(Encounter.Status.finished)
         .encounterClass(Encounter.EncounterClass.emergency)
@@ -99,7 +98,6 @@ public class SwaggerEncounter {
    */
   public static final Encounter.Bundle encounterBundle() {
     return Encounter.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -126,7 +124,6 @@ public class SwaggerEncounter {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Encounter/dc7f6fcc-41f9-5be9-a364-0b0aa938917a")
                     .resource(
                         Encounter.builder()
-                            .resourceType("Encounter")
                             .id("dc7f6fcc-41f9-5be9-a364-0b0aa938917a")
                             .status(Encounter.Status.finished)
                             .encounterClass(Encounter.EncounterClass.emergency)

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerEncounter.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerEncounter.java
@@ -10,7 +10,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Encounter;
 
 public class SwaggerEncounter {
-
   /**
    * An example Encounter.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerImmunization.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerImmunization.java
@@ -14,7 +14,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Immunization;
 
 public class SwaggerImmunization {
-
   /**
    * An example Immunization.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerImmunization.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerImmunization.java
@@ -22,7 +22,6 @@ public class SwaggerImmunization {
    */
   public static Immunization immunization() {
     return Immunization.builder()
-        .resourceType("Immunization")
         .id("1fd82e3a-a95b-5c04-9a68-c8ddf740ea0c")
         .status(Immunization.Status.completed)
         .date("2017-04-24T01:15:52Z")
@@ -63,7 +62,6 @@ public class SwaggerImmunization {
    */
   public static Immunization.Bundle immunizationBundle() {
     return Immunization.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -90,7 +88,6 @@ public class SwaggerImmunization {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Immunization/1fd82e3a-a95b-5c04-9a68-c8ddf740ea0c")
                     .resource(
                         Immunization.builder()
-                            .resourceType("Immunization")
                             .id("1fd82e3a-a95b-5c04-9a68-c8ddf740ea0c")
                             .status(Immunization.Status.completed)
                             .date("2017-04-24T01:15:52Z")

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerLocation.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerLocation.java
@@ -12,7 +12,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Location;
 
 public class SwaggerLocation {
-
   /**
    * An example Location.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerLocation.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerLocation.java
@@ -20,7 +20,6 @@ public class SwaggerLocation {
    */
   public static Location location() {
     return Location.builder()
-        .resourceType("Location")
         .id("96aee2f5-a2ce-588f-8352-f6ea61f0959d")
         .status(Location.Status.active)
         .name("VAMC ALBANY")
@@ -48,7 +47,6 @@ public class SwaggerLocation {
    */
   public static Location.Bundle locationBundle() {
     return Location.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -75,7 +73,6 @@ public class SwaggerLocation {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Location/96aee2f5-a2ce-588f-8352-f6ea61f0959d")
                     .resource(
                         Location.builder()
-                            .resourceType("Location")
                             .id("96aee2f5-a2ce-588f-8352-f6ea61f0959d")
                             .status(Location.Status.active)
                             .name("VAMC ALBANY")

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedication.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedication.java
@@ -20,7 +20,6 @@ public class SwaggerMedication {
    */
   public static Medication medication() {
     return Medication.builder()
-        .resourceType("Medication")
         .id("f4163f35-1565-552b-a1b9-a2f8870e6f4a")
         .code(
             CodeableConcept.builder()
@@ -48,7 +47,6 @@ public class SwaggerMedication {
    */
   public static final Medication.Bundle medicationBundle() {
     return Medication.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -75,7 +73,6 @@ public class SwaggerMedication {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Medication/f4163f35-1565-552b-a1b9-a2f8870e6f4a")
                     .resource(
                         Medication.builder()
-                            .resourceType("Medication")
                             .id("f4163f35-1565-552b-a1b9-a2f8870e6f4a")
                             .code(
                                 CodeableConcept.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedication.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedication.java
@@ -12,7 +12,6 @@ import gov.va.api.health.dstu2.api.datatypes.Coding;
 import gov.va.api.health.dstu2.api.resources.Medication;
 
 public class SwaggerMedication {
-
   /**
    * An example Medication.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationDispense.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationDispense.java
@@ -16,7 +16,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.MedicationDispense;
 
 public class SwaggerMedicationDispense {
-
   /**
    * An example MedicationDispense.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationDispense.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationDispense.java
@@ -24,7 +24,6 @@ public class SwaggerMedicationDispense {
    */
   public static MedicationDispense medicationDispense() {
     return MedicationDispense.builder()
-        .resourceType("MedicationDispense")
         .id("3ba8c63c-bac2-5f98-b7cd-161792919216")
         .identifier(
             Identifier.builder()
@@ -106,7 +105,6 @@ public class SwaggerMedicationDispense {
    */
   public static MedicationDispense.Bundle medicationDispenseBundle() {
     return MedicationDispense.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1155)
         .link(
@@ -138,7 +136,6 @@ public class SwaggerMedicationDispense {
                         "https://sandbox-api.va.gov/services/argonaut/v0/MedicationDispense/2f587c16-5182-59a5-bdcb-518c7c501f37")
                     .resource(
                         MedicationDispense.builder()
-                            .resourceType("MedicationDispense")
                             .id("2f587c16-5182-59a5-bdcb-518c7c501f37")
                             .identifier(
                                 Identifier.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationOrder.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationOrder.java
@@ -20,7 +20,6 @@ public class SwaggerMedicationOrder {
    */
   public static MedicationOrder medicationOrder() {
     return MedicationOrder.builder()
-        .resourceType("MedicationOrder")
         .id("f07dd74e-844e-5463-99d4-0ca4d5cbeb41")
         .dateWritten("2013-04-14T06:00:00Z")
         .status(MedicationOrder.Status.active)
@@ -54,7 +53,6 @@ public class SwaggerMedicationOrder {
    */
   public static final MedicationOrder.Bundle medicationOrderBundle() {
     return MedicationOrder.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -81,7 +79,6 @@ public class SwaggerMedicationOrder {
                         "https://sandbox-api.va.gov/services/argonaut/v0/MedicationOrder/f07dd74e-844e-5463-99d4-0ca4d5cbeb41")
                     .resource(
                         MedicationOrder.builder()
-                            .resourceType("MedicationOrder")
                             .id("f07dd74e-844e-5463-99d4-0ca4d5cbeb41")
                             .dateWritten("2013-04-14T06:00:00Z")
                             .status(MedicationOrder.Status.active)

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationOrder.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationOrder.java
@@ -12,7 +12,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.MedicationOrder;
 
 public class SwaggerMedicationOrder {
-
   /**
    * An example MedicationOrder.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationStatement.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationStatement.java
@@ -21,7 +21,6 @@ public class SwaggerMedicationStatement {
    */
   public static MedicationStatement medicationStatement() {
     return MedicationStatement.builder()
-        .resourceType("MedicationStatement")
         .id("1f46363d-af9b-5ba5-acda-b384373a9af2")
         .patient(
             Reference.builder()
@@ -57,7 +56,6 @@ public class SwaggerMedicationStatement {
    */
   public static MedicationStatement.Bundle medicationStatementBundle() {
     return MedicationStatement.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -84,7 +82,6 @@ public class SwaggerMedicationStatement {
                         "https://sandbox-api.va.gov/services/argonaut/v0/MedicationStatement/1f46363d-af9b-5ba5-acda-b384373a9af2")
                     .resource(
                         MedicationStatement.builder()
-                            .resourceType("MedicationStatement")
                             .id("1f46363d-af9b-5ba5-acda-b384373a9af2")
                             .patient(
                                 Reference.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationStatement.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerMedicationStatement.java
@@ -13,7 +13,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.MedicationStatement;
 
 public class SwaggerMedicationStatement {
-
   /**
    * An example MedicationStatement.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerObservation.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerObservation.java
@@ -14,7 +14,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Observation;
 
 public class SwaggerObservation {
-
   /**
    * An example Observation.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerObservation.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerObservation.java
@@ -22,7 +22,6 @@ public class SwaggerObservation {
    */
   public static Observation observation() {
     return Observation.builder()
-        .resourceType("Observation")
         .id("7889e577-88d6-5e6f-8a4d-fb6988b7b3c1")
         .status(Observation.Status._final)
         .category(
@@ -69,7 +68,6 @@ public class SwaggerObservation {
    */
   public static Observation.Bundle observationBundle() {
     return Observation.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -96,7 +94,6 @@ public class SwaggerObservation {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Observation/7889e577-88d6-5e6f-8a4d-fb6988b7b3c1")
                     .resource(
                         Observation.builder()
-                            .resourceType("Observation")
                             .id("7889e577-88d6-5e6f-8a4d-fb6988b7b3c1")
                             .status(Observation.Status._final)
                             .category(

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOperationOutcome.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOperationOutcome.java
@@ -6,7 +6,6 @@ import gov.va.api.health.dstu2.api.datatypes.CodeableConcept;
 import gov.va.api.health.dstu2.api.resources.OperationOutcome;
 
 public class SwaggerOperationOutcome {
-
   /**
    * An example OperationOutcome.
    *
@@ -14,7 +13,6 @@ public class SwaggerOperationOutcome {
    */
   public static OperationOutcome operationOutcome() {
     return OperationOutcome.builder()
-        .resourceType("OperationOutcome")
         .issue(
             asList(
                 OperationOutcome.Issue.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOrganization.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOrganization.java
@@ -14,7 +14,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Organization;
 
 public class SwaggerOrganization {
-
   /**
    * An example Organization.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOrganization.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerOrganization.java
@@ -22,7 +22,6 @@ public class SwaggerOrganization {
    */
   public static Organization organization() {
     return Organization.builder()
-        .resourceType("Organization")
         .id("6a96677d-f487-52bb-befd-6c90c7f49fa6")
         .active(true)
         .type(
@@ -60,7 +59,6 @@ public class SwaggerOrganization {
    */
   public static Organization.Bundle organizationBundle() {
     return Organization.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -87,7 +85,6 @@ public class SwaggerOrganization {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Organization/6a96677d-f487-52bb-befd-6c90c7f49fa6")
                     .resource(
                         Organization.builder()
-                            .resourceType("Organization")
                             .id("6a96677d-f487-52bb-befd-6c90c7f49fa6")
                             .active(true)
                             .type(

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPatient.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPatient.java
@@ -17,7 +17,6 @@ import gov.va.api.health.dstu2.api.elements.Extension;
 import gov.va.api.health.dstu2.api.resources.Patient;
 
 public class SwaggerPatient {
-
   /**
    * An example Patient.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPatient.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPatient.java
@@ -26,7 +26,6 @@ public class SwaggerPatient {
   public static Patient patient() {
     return Patient.builder()
         .id("2000163")
-        .resourceType("Patient")
         .extension(
             asList(
                 Extension.builder()
@@ -146,7 +145,6 @@ public class SwaggerPatient {
    */
   public static Patient.Bundle patientBundle() {
     return Patient.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -174,7 +172,6 @@ public class SwaggerPatient {
                     .resource(
                         Patient.builder()
                             .id("2000163")
-                            .resourceType("Patient")
                             .extension(
                                 asList(
                                     Extension.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPractitioner.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPractitioner.java
@@ -23,7 +23,6 @@ public class SwaggerPractitioner {
    */
   public static Practitioner practitioner() {
     return Practitioner.builder()
-        .resourceType("Practitioner")
         .id("9e8531cb-8069-5328-b737-938fa044a4e2")
         .active(true)
         .name(
@@ -118,7 +117,6 @@ public class SwaggerPractitioner {
    */
   public static Practitioner.Bundle practitionerBundle() {
     return Practitioner.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -145,7 +143,6 @@ public class SwaggerPractitioner {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Practitioner/9e8531cb-8069-5328-b737-938fa044a4e2")
                     .resource(
                         Practitioner.builder()
-                            .resourceType("Practitioner")
                             .id("9e8531cb-8069-5328-b737-938fa044a4e2")
                             .active(true)
                             .name(

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPractitioner.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerPractitioner.java
@@ -15,7 +15,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Practitioner;
 
 public class SwaggerPractitioner {
-
   /**
    * An example Practitioner.
    *

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerProcedure.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerProcedure.java
@@ -21,7 +21,6 @@ public class SwaggerProcedure {
    */
   public static Procedure procedure() {
     return Procedure.builder()
-        .resourceType("Procedure")
         .id("532070f1-cb7b-582e-9380-9e0ef27bc817")
         .subject(
             Reference.builder()
@@ -51,7 +50,6 @@ public class SwaggerProcedure {
    */
   public static Procedure.Bundle procedureBundle() {
     return Procedure.Bundle.builder()
-        .resourceType("Bundle")
         .type(BundleType.searchset)
         .total(1)
         .link(
@@ -78,7 +76,6 @@ public class SwaggerProcedure {
                         "https://sandbox-api.va.gov/services/argonaut/v0/Procedure/532070f1-cb7b-582e-9380-9e0ef27bc817")
                     .resource(
                         Procedure.builder()
-                            .resourceType("Procedure")
                             .id("532070f1-cb7b-582e-9380-9e0ef27bc817")
                             .subject(
                                 Reference.builder()

--- a/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerProcedure.java
+++ b/argonaut-dstu2-examples/src/main/java/gov/va/api/health/dstu2/api/swaggerexamples/SwaggerProcedure.java
@@ -13,7 +13,6 @@ import gov.va.api.health.dstu2.api.elements.Reference;
 import gov.va.api.health.dstu2.api.resources.Procedure;
 
 public class SwaggerProcedure {
-
   /**
    * An example Procedure.
    *

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/AllergyIntolerance.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/AllergyIntolerance.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -46,7 +48,7 @@ import lombok.NoArgsConstructor;
         "${dstu2.allergyIntolerance:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerAllergyIntolerance#allergyIntolerance}")
 public class AllergyIntolerance implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "AllergyIntolerance";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -144,6 +146,7 @@ public class AllergyIntolerance implements Resource {
           "${dstu2.allergyIntoleranceBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerAllergyIntolerance#allergyIntoleranceBundle}")
   public static class Bundle extends AbstractBundle<AllergyIntolerance.Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -156,7 +159,17 @@ public class AllergyIntolerance implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Appointment.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Appointment.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,7 +45,7 @@ import lombok.NoArgsConstructor;
         "${dstu2.appointment:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerAppointment#appointment}")
 public class Appointment implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Appointment";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -111,6 +113,7 @@ public class Appointment implements DomainResource {
           "${dstu2.appointmentBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerAppointment#appointmentBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -123,7 +126,17 @@ public class Appointment implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Condition.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Condition.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -61,10 +63,11 @@ import lombok.NoArgsConstructor;
       message = "Only one abatement value may be specified")
 })
 public class Condition implements Resource {
+  @NotBlank @Builder.Default String resourceType = "Condition";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)
@@ -146,6 +149,7 @@ public class Condition implements Resource {
           "${dstu2.conditionBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerCondition#conditionBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -158,7 +162,17 @@ public class Condition implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Conformance.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Conformance.java
@@ -34,10 +34,11 @@ import lombok.NoArgsConstructor;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Schema(description = "http://hl7.org/fhir/DSTU2/conformance.html")
 public class Conformance implements Resource {
+  @NotBlank @Builder.Default String resourceType = "Conformance";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank @Builder.Default String resourceType = "Conformance";
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/DiagnosticReport.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/DiagnosticReport.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -54,10 +56,11 @@ import org.apache.commons.lang3.StringUtils;
     fields = {"effectiveDateTime", "effectivePeriod"},
     message = "Only one effective value may be specified")
 public class DiagnosticReport implements Resource {
+  @NotBlank @Builder.Default String resourceType = "DiagnosticReport";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)
@@ -147,6 +150,7 @@ public class DiagnosticReport implements Resource {
               + "gov.va.api.health.dstu2.api.swaggerexamples."
               + "SwaggerDiagnosticReport#diagnosticReportBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -159,7 +163,17 @@ public class DiagnosticReport implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Encounter.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Encounter.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +45,7 @@ import lombok.NoArgsConstructor;
         "${dstu2.encounter:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerEncounter#encounter}")
 public class Encounter implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Encounter";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -119,6 +121,7 @@ public class Encounter implements DomainResource {
           "${dstu2.encounterBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerEncounter#encounterBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -131,7 +134,17 @@ public class Encounter implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Immunization.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Immunization.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -50,7 +52,7 @@ import lombok.NoArgsConstructor;
   @ExactlyOneOf(fields = {"reported", "_reported"})
 })
 public class Immunization implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Immunization";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -121,6 +123,7 @@ public class Immunization implements Resource {
           "${dstu2.immunizationBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerImmunization#immunizationBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -133,7 +136,17 @@ public class Immunization implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Location.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Location.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.dstu2.api.Fhir;
@@ -41,7 +43,7 @@ import lombok.NoArgsConstructor;
     example =
         "${dstu2.location:gov.va.api.health.dstu2.api.swaggerexamples.SwaggerLocation#location}")
 public class Location implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Location";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -108,6 +110,7 @@ public class Location implements DomainResource {
           "${dstu2.locationBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerLocation#locationBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -120,7 +123,17 @@ public class Location implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Medication.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Medication.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,10 +45,11 @@ import lombok.NoArgsConstructor;
         "${dstu2.medication:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerMedication#medication}")
 public class Medication implements Resource {
+  @NotBlank @Builder.Default String resourceType = "Medication";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)
@@ -99,6 +102,7 @@ public class Medication implements Resource {
           "${dstu2.medicationBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerMedication#medicationBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -111,7 +115,17 @@ public class Medication implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationDispense.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationDispense.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,7 +60,7 @@ import lombok.NoArgsConstructor;
     fields = {"medicationCodeableConcept", "medicationReference"},
     message = "Exactly one medication field must be specified")
 public class MedicationDispense implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "MedicationDispense";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -150,6 +152,7 @@ public class MedicationDispense implements DomainResource {
               + "gov.va.api.health.dstu2.api.swaggerexamples."
               + "SwaggerMedicationDispense#medicationDispenseBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -162,7 +165,17 @@ public class MedicationDispense implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationOrder.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationOrder.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -64,7 +66,7 @@ import lombok.NoArgsConstructor;
       message = "Exactly one prescriber field must be specified"),
 })
 public class MedicationOrder implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "MedicationOrder";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -130,6 +132,7 @@ public class MedicationOrder implements Resource {
           "${dstu2.medicationOrderBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerMedicationOrder#medicationOrderBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -142,7 +145,17 @@ public class MedicationOrder implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationStatement.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/MedicationStatement.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -62,7 +64,7 @@ import lombok.NoArgsConstructor;
     fields = {"medicationCodeableConcept", "medicationReference"},
     message = "Exactly one medication value must be specified")
 public class MedicationStatement implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "MedicationStatement";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -126,6 +128,7 @@ public class MedicationStatement implements Resource {
           "${dstu2.medicationStatementBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerMedicationStatement#medicationStatementBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -138,7 +141,17 @@ public class MedicationStatement implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Observation.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Observation.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -75,7 +77,7 @@ import org.apache.commons.lang3.StringUtils;
       message = "Only one value field may be specified")
 })
 public class Observation implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Observation";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -184,6 +186,7 @@ public class Observation implements Resource {
               + "gov.va.api.health.dstu2.api.swaggerexamples."
               + "SwaggerObservation#observationBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -196,7 +199,17 @@ public class Observation implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/OperationOutcome.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/OperationOutcome.java
@@ -32,10 +32,11 @@ import lombok.NoArgsConstructor;
         "${dstu2.operationOutcome:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerOperationOutcome#operationOutcome}")
 public class OperationOutcome implements DomainResource {
+  @NotBlank @Builder.Default String resourceType = "OperationOutcome";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Organization.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Organization.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.dstu2.api.Fhir;
@@ -43,7 +45,7 @@ import lombok.NoArgsConstructor;
         "${dstu2.organization:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerOrganization#organization}")
 public class Organization implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Organization";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -81,6 +83,7 @@ public class Organization implements DomainResource {
           "${dstu2.organizationBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerOrganization#organizationBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -93,7 +96,17 @@ public class Organization implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Patient.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Patient.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -57,10 +59,11 @@ import lombok.NoArgsConstructor;
       message = "Only one multiple birth value may be specified")
 })
 public class Patient implements Resource {
+  @NotBlank @Builder.Default String resourceType = "Patient";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)
@@ -154,6 +157,7 @@ public class Patient implements Resource {
           "${dstu2.patientBundle:gov.va.api.health.dstu2.api.swaggerexamples."
               + "SwaggerPatient#patientBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -166,7 +170,17 @@ public class Patient implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Practitioner.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Practitioner.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.dstu2.api.Fhir;
@@ -45,7 +47,7 @@ import lombok.NoArgsConstructor;
         "${dstu2.practitioner:gov.va.api.health.dstu2.api.swaggerexamples"
             + ".SwaggerPractitioner#practitioner}")
 public class Practitioner implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Practitioner";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -129,6 +131,7 @@ public class Practitioner implements DomainResource {
           "${dstu2.practitionerBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerPractitioner#practitionerBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -141,7 +144,17 @@ public class Practitioner implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Procedure.java
+++ b/argonaut-dstu2/src/main/java/gov/va/api/health/dstu2/api/resources/Procedure.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.dstu2.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +61,7 @@ import lombok.NoArgsConstructor;
         fields = {"reasonCodeableConcept", "reasonReference"},
         message = "At most one reason may be specified."))
 public class Procedure implements Resource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Procedure";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -131,6 +133,7 @@ public class Procedure implements Resource {
           "${dstu2.procedureBundle:gov.va.api.health.dstu2.api.swaggerexamples"
               + ".SwaggerProcedure#procedureBundle}")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -143,7 +146,17 @@ public class Procedure implements Resource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleAppointments.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleAppointments.java
@@ -17,7 +17,6 @@ public class SampleAppointments {
 
   public Appointment appointment() {
     return Appointment.builder()
-        .resourceType("Appointment")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleConditions.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleConditions.java
@@ -19,7 +19,6 @@ public class SampleConditions {
   public Condition condition() {
     return Condition.builder()
         .id("1234")
-        .resourceType("Diagnostic Report")
         .meta(meta())
         .implicitRules("https://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleConformance.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleConformance.java
@@ -41,7 +41,6 @@ public class SampleConformance {
   public Conformance conformance() {
     return Conformance.builder()
         .id("c1")
-        .resourceType("Conformance")
         .implicitRules("https://example.com")
         .language("en")
         .text(narrative())

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleDiagnosticReports.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleDiagnosticReports.java
@@ -40,7 +40,6 @@ public class SampleDiagnosticReports {
   public DiagnosticReport diagnosticReport() {
     return DiagnosticReport.builder()
         .id("1234")
-        .resourceType("Diagnostic Report")
         .meta(meta())
         .implicitRules("https://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleEncounters.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleEncounters.java
@@ -25,7 +25,6 @@ public class SampleEncounters {
   public Encounter encounter() {
     return Encounter.builder()
         .id("1234")
-        .resourceType("Encounter")
         .meta(meta())
         .implicitRules("http://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleExtensions.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleExtensions.java
@@ -243,7 +243,6 @@ public class SampleExtensions {
 
   private Patient patientWith(List<Extension> extension) {
     return Patient.builder()
-        .resourceType("Patient")
         .extension(extension)
         .identifier(identifier())
         .gender(Patient.Gender.unknown)

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleImmunizations.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleImmunizations.java
@@ -29,7 +29,6 @@ public class SampleImmunizations {
 
   public Immunization immunization() {
     return Immunization.builder()
-        .resourceType("Immunization")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationDispenses.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationDispenses.java
@@ -33,7 +33,6 @@ public class SampleMedicationDispenses {
 
   public MedicationDispense medicationDispense() {
     return MedicationDispense.builder()
-        .resourceType("MedicationDispense")
         .id("789")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationOrders.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationOrders.java
@@ -48,7 +48,6 @@ public class SampleMedicationOrders {
 
   public MedicationOrder medicationOrder() {
     return MedicationOrder.builder()
-        .resourceType("MedicationOrder")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationStatements.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedicationStatements.java
@@ -42,7 +42,6 @@ public class SampleMedicationStatements {
 
   public MedicationStatement medicationStatement() {
     return MedicationStatement.builder()
-        .resourceType("MedicationStatement")
         .id("ms1")
         .meta(meta())
         .implicitRules("rules")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedications.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleMedications.java
@@ -58,7 +58,6 @@ public class SampleMedications {
   public Medication medication() {
     return Medication.builder()
         .id("1234")
-        .resourceType("Medication")
         .meta(meta())
         .implicitRules("http://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleObservations.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleObservations.java
@@ -50,7 +50,6 @@ public class SampleObservations {
   public Observation observation() {
     return Observation.builder()
         .id("1234")
-        .resourceType("Observation")
         .meta(meta())
         .implicitRules("http://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleOrganizations.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleOrganizations.java
@@ -13,7 +13,6 @@ public class SampleOrganizations {
 
   public Organization organization() {
     return Organization.builder()
-        .resourceType("Organization")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SamplePatients.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SamplePatients.java
@@ -67,7 +67,6 @@ public class SamplePatients {
   public Patient patient() {
     return Patient.builder()
         .id("1234")
-        .resourceType("Patient")
         .meta(meta())
         .implicitRules("http://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SamplePractitioners.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SamplePractitioners.java
@@ -16,7 +16,6 @@ public class SamplePractitioners {
 
   public Practitioner practitioner() {
     return Practitioner.builder()
-        .resourceType("Practitioner")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleProcedures.java
+++ b/argonaut-dstu2/src/test/java/gov/va/api/health/dstu2/api/samples/SampleProcedures.java
@@ -37,7 +37,6 @@ public class SampleProcedures {
   public Procedure procedure() {
     return Procedure.builder()
         .id("1234")
-        .resourceType("Procedure")
         .meta(meta())
         .implicitRules("http://HelloRules.com")
         .language("Hello Language")

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/CapabilityStatement.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/CapabilityStatement.java
@@ -33,10 +33,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class CapabilityStatement implements DomainResource {
+  @NotBlank @Builder.Default String resourceType = "CapabilityStatement";
+
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Endpoint.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Endpoint.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.stu3.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -41,7 +43,7 @@ import lombok.NoArgsConstructor;
 @Schema(
     description = "http://www.fhir.org/guides/argonaut/pd/StructureDefinition-argo-endpoint.html")
 public class Endpoint implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Endpoint";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -125,6 +127,7 @@ public class Endpoint implements DomainResource {
   @JsonDeserialize(builder = Endpoint.Bundle.BundleBuilder.class)
   @Schema(name = "Endpoint")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -137,7 +140,17 @@ public class Endpoint implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 }

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Location.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Location.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.stu3.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.stu3.api.Fhir;
@@ -42,7 +44,7 @@ import lombok.NoArgsConstructor;
 @Schema(
     description = "http://www.fhir.org/guides/argonaut/pd/StructureDefinition-argo-location.html")
 public class Location implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Location";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -110,6 +112,7 @@ public class Location implements DomainResource {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @JsonDeserialize(builder = Location.Bundle.BundleBuilder.class)
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -122,7 +125,17 @@ public class Location implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Location.Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/OperationOutcome.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/OperationOutcome.java
@@ -28,11 +28,11 @@ import lombok.NoArgsConstructor;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @Schema(description = "https://www.hl7.org/fhir/operationoutcome.html")
 public class OperationOutcome implements DomainResource {
+  @NotBlank @Builder.Default String resourceType = "OperationOutcome";
 
   @Pattern(regexp = Fhir.ID)
   String id;
 
-  @NotBlank String resourceType;
   @Valid Meta meta;
 
   @Pattern(regexp = Fhir.URI)

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Organization.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Organization.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.stu3.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.stu3.api.Fhir;
@@ -43,7 +45,7 @@ import lombok.NoArgsConstructor;
     description =
         "http://www.fhir.org/guides/argonaut/pd/StructureDefinition-argo-organization.html")
 public class Organization implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Organization";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -80,6 +82,7 @@ public class Organization implements DomainResource {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @JsonDeserialize(builder = Organization.Bundle.BundleBuilder.class)
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -92,7 +95,17 @@ public class Organization implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Practitioner.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/Practitioner.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.stu3.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.stu3.api.Fhir;
@@ -45,7 +47,7 @@ import lombok.NoArgsConstructor;
     description =
         "http://www.fhir.org/guides/argonaut/pd/StructureDefinition-argo-practitioner.html")
 public class Practitioner implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "Practitioner";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -123,6 +125,7 @@ public class Practitioner implements DomainResource {
   @JsonDeserialize(builder = Practitioner.Bundle.BundleBuilder.class)
   @Schema(name = "PractitionerBundle")
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -135,7 +138,17 @@ public class Practitioner implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/PractitionerRole.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/PractitionerRole.java
@@ -126,7 +126,6 @@ public class PractitionerRole implements DomainResource {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @JsonDeserialize(builder = PractitionerRole.Entry.EntryBuilder.class)
   public static class Entry extends AbstractEntry<PractitionerRole> {
-    /** Builder constructor. */
     @Builder
     public Entry(
         @Pattern(regexp = Fhir.ID) String id,

--- a/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/PractitionerRole.java
+++ b/argonaut-stu3/src/main/java/gov/va/api/health/stu3/api/resources/PractitionerRole.java
@@ -1,5 +1,7 @@
 package gov.va.api.health.stu3.api.resources;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.va.api.health.stu3.api.Fhir;
@@ -40,7 +42,7 @@ import lombok.NoArgsConstructor;
     description =
         "http://www.fhir.org/guides/argonaut/pd/StructureDefinition-argo-practitionerrole.html")
 public class PractitionerRole implements DomainResource {
-  @NotBlank String resourceType;
+  @NotBlank @Builder.Default String resourceType = "PractitionerRole";
 
   @Pattern(regexp = Fhir.ID)
   String id;
@@ -91,6 +93,7 @@ public class PractitionerRole implements DomainResource {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @JsonDeserialize(builder = PractitionerRole.Bundle.BundleBuilder.class)
   public static class Bundle extends AbstractBundle<Entry> {
+    /** Builder constructor. */
     @Builder
     public Bundle(
         @NotBlank String resourceType,
@@ -103,7 +106,17 @@ public class PractitionerRole implements DomainResource {
         @Valid List<BundleLink> link,
         @Valid List<Entry> entry,
         @Valid Signature signature) {
-      super(resourceType, id, meta, implicitRules, language, type, total, link, entry, signature);
+      super(
+          defaultString(resourceType, "Bundle"),
+          id,
+          meta,
+          implicitRules,
+          language,
+          type,
+          total,
+          link,
+          entry,
+          signature);
     }
   }
 
@@ -113,6 +126,7 @@ public class PractitionerRole implements DomainResource {
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   @JsonDeserialize(builder = PractitionerRole.Entry.EntryBuilder.class)
   public static class Entry extends AbstractEntry<PractitionerRole> {
+    /** Builder constructor. */
     @Builder
     public Entry(
         @Pattern(regexp = Fhir.ID) String id,

--- a/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleCapabilityStatement.java
+++ b/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleCapabilityStatement.java
@@ -41,7 +41,6 @@ public class SampleCapabilityStatement {
   public CapabilityStatement capabilityStatement() {
     return CapabilityStatement.builder()
         .id("c1")
-        .resourceType("CapabilityStatement")
         .implicitRules("https://example.com")
         .language("en")
         .text(narrative())

--- a/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleEndpoints.java
+++ b/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleEndpoints.java
@@ -12,7 +12,6 @@ public class SampleEndpoints {
 
   public Endpoint endpoint() {
     return Endpoint.builder()
-        .resourceType("endpoint")
         .status(Status.active)
         .name("My Name")
         .connectionType(Coding.builder().build())

--- a/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleOrganizations.java
+++ b/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SampleOrganizations.java
@@ -12,7 +12,6 @@ public class SampleOrganizations {
 
   public Organization organization() {
     return Organization.builder()
-        .resourceType("Organization")
         .id("2222")
         .meta(meta())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SamplePractitionerRoles.java
+++ b/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SamplePractitionerRoles.java
@@ -15,7 +15,6 @@ public class SamplePractitionerRoles {
 
   public PractitionerRole practitionerRole() {
     return PractitionerRole.builder()
-        .resourceType("PractitionerRole")
         .id("2222")
         .meta(Meta.builder().build())
         .implicitRules("http://HelloRules.com")

--- a/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SamplePractitioners.java
+++ b/argonaut-stu3/src/test/java/gov/va/api/health/stu3/api/samples/SamplePractitioners.java
@@ -14,7 +14,6 @@ public class SamplePractitioners {
 
   public Practitioner practitioner() {
     return Practitioner.builder()
-        .resourceType("Practitioner")
         .id("2222")
         .meta(Meta.builder().build())
         .implicitRules("http://HelloRules.com")


### PR DESCRIPTION
Similar to https://github.com/department-of-veterans-affairs/health-apis-fhir-resources/pull/113, set default `resourceType` for dstu2 and stu3 resources. This is tangentially related to DQ clean-up of the `Practitioner` and `PractitionerRole` transformers.